### PR TITLE
feat: add ability to pass opts to the engine

### DIFF
--- a/flipt-client-ruby/lib/evaluation.rb
+++ b/flipt-client-ruby/lib/evaluation.rb
@@ -24,8 +24,8 @@ module Flipt
     extend FFI::Library
     ffi_lib File.expand_path(platform_specific_lib, __dir__)
 
-    # void *initialize_engine(const char *const *namespaces);
-    attach_function :initialize_engine, [:pointer], :pointer
+    # void *initialize_engine(const char *const *namespaces, const char *opts);
+    attach_function :initialize_engine, [:pointer, :string], :pointer
     # void destroy_engine(void *engine_ptr);
     attach_function :destroy_engine, [:pointer], :void
     # const char *variant(void *engine_ptr, const char *evaluation_request);
@@ -41,7 +41,7 @@ module Flipt
         ns[i].put_pointer(0, FFI::MemoryPointer.from_string(namespace))
       end
 
-      @engine = self.class.initialize_engine(ns)
+      @engine = self.class.initialize_engine(ns, opts.to_json)
       ObjectSpace.define_finalizer(self, self.class.finalize(@engine))
     end
 

--- a/flipt-engine/examples/evaluation.rs
+++ b/flipt-engine/examples/evaluation.rs
@@ -4,9 +4,11 @@ use fliptengine::{self, evaluator, parser};
 use std::collections::HashMap;
 
 fn main() {
-    let evaluator =
-        evaluator::Evaluator::new(vec!["default".into()], Box::new(parser::HTTPParser::new()));
-    let eng = fliptengine::Engine::new(evaluator.unwrap());
+    let evaluator = evaluator::Evaluator::new(
+        vec!["default".into()],
+        Box::new(parser::HTTPParser::new("http://localhost:8080")),
+    );
+    let eng = fliptengine::Engine::new(evaluator.unwrap(), Default::default());
     let mut context: HashMap<String, String> = HashMap::new();
     context.insert("fizz".into(), "buzz".into());
 

--- a/flipt-engine/src/parser/mod.rs
+++ b/flipt-engine/src/parser/mod.rs
@@ -1,10 +1,9 @@
 use snafu::{prelude::*, Whatever};
-use std::env;
 
 use crate::models::source;
 
 pub trait Parser {
-    fn parse(&self, namespace: String) -> Result<source::Document, Whatever>;
+    fn parse(&self, namespace: &str) -> Result<source::Document, Whatever>;
 }
 
 pub struct HTTPParser {
@@ -13,25 +12,22 @@ pub struct HTTPParser {
 }
 
 impl HTTPParser {
-    pub fn new() -> Self {
+    pub fn new(url: &str) -> Self {
         // We will allow the following line to panic when an error is encountered.
         let http_client = reqwest::blocking::Client::builder()
             .timeout(std::time::Duration::from_secs(10))
             .build()
             .unwrap();
 
-        // TODO: This should be a config option and not an env var.
-        let http_url = env::var("FLIPT_URL").unwrap_or(String::from("http://localhost:8080"));
-
         Self {
             http_client,
-            http_url,
+            http_url: url.to_string(),
         }
     }
 }
 
 impl Parser for HTTPParser {
-    fn parse(&self, namespace: String) -> Result<source::Document, Whatever> {
+    fn parse(&self, namespace: &str) -> Result<source::Document, Whatever> {
         let response = match self
             .http_client
             .get(format!(
@@ -77,7 +73,7 @@ impl TestParser {
 
 #[cfg(test)]
 impl Parser for TestParser {
-    fn parse(&self, _: String) -> Result<source::Document, Whatever> {
+    fn parse(&self, _: &str) -> Result<source::Document, Whatever> {
         let f = match &self.path {
             Some(path) => path.to_owned(),
             None => {

--- a/flipt-engine/src/store/mod.rs
+++ b/flipt-engine/src/store/mod.rs
@@ -44,7 +44,7 @@ impl Snapshot {
         let mut ns: HashMap<String, Namespace> = HashMap::new();
 
         for n in namespaces {
-            let doc = parser.parse(n.clone())?;
+            let doc = parser.parse(n)?;
 
             let mut flags: HashMap<String, flipt::Flag> = HashMap::new();
             let mut eval_rules: HashMap<String, Vec<flipt::EvaluationRule>> = HashMap::new();


### PR DESCRIPTION
Fixes: FLI-692

Adds the ability to send engine options (ie `http_url`, `update_interval`) via JSON to the engine from the clients.

I haven't verified this actually works yet.. hoping that the ITs will allow for that