### PR TITLE
chore: update README to reflect usage of build script

### DIFF
--- a/flipt-engine/README.md
+++ b/flipt-engine/README.md
@@ -27,16 +27,10 @@ TODO: Add more details
 cargo build --release
 ```
 
+There are some language SDKs that might require a C file header which has the definitions of the functions accessible through the FFI layer. The `cargo build` command will use a build script to generate this header file by way of the [cbindgen](https://github.com/mozilla/cbindgen) tool.
+
 ### Test
 
 ```bash
 cargo test
-```
-
-### Generate the FFI Header
-
-Requires [cbindgen](https://github.com/mozilla/cbindgen)
-
-```bash
-cbindgen --config cbindgen.toml --crate flipt-client-engine --output flipt_engine.h
 ```


### PR DESCRIPTION
The README currently tells users that they should download the `cbindgen` tool, but that is not the case since the functionality is now moved to a build script.