### PR TITLE
chore: package/cross-compile

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -29,6 +29,16 @@ jobs:
           target: ${{ matrix.platform.target }}
           override: true
 
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.platform.target}}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build Rust ${{ matrix.platform.name }}
         uses: actions-rs/cargo@v1
         with:
@@ -36,11 +46,8 @@ jobs:
           args: --target ${{ matrix.platform.target }} --release
           use-cross: true
 
-      - run: |
-          tree
-
       - uses: actions/upload-artifact@v4
         with:
           name: libfliptengine-${{ matrix.platform.name }}
-          path: target/release/*.(so|dll|dylib|h)
+          path: target/release/${{ matrix.platform.target}}/release/*.(so|dll|dylib|h)
           retention-days: 5

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -12,32 +12,31 @@ jobs:
       matrix:
         platform:
           - name: Linux-x86_64
-            os: [ubuntu-latest]
-            target: [x86_64-unknown-linux-gnu]
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
           - name: Linux-armv7
-            os: [ubuntu-latest]
-            target: [armv7-unknown-linux-gnueabihf]
+            os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
 
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust
+      - name: Install Rust ${{ matrix.platform.name }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: ${{ matrix.platform.target }}
           override: true
 
-      - uses: actions-rs/cargo@v1
+      - name: Build Rust ${{ matrix.platform.name }}
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --target ${{ matrix.platform.target }} --release
           use-cross: true
 
       - uses: actions/upload-artifact@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: libfliptengine-${{ matrix.platform.name }}
           path: target/${{ matrix.platform.target }}/release/*.(so|dll|dylib|h)

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -1,9 +1,7 @@
-name: Build Rust Engine
+name: Package Rust Engine
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -49,5 +49,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: libfliptengine-${{ matrix.platform.name }}
-          path: target/${{ matrix.platform.target}}/release/*.(so|dll|dylib)
+          path: target/**/*.(so|dll|dylib)
           retention-days: 5

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -12,17 +12,19 @@ jobs:
       matrix:
         platform:
           - name: Linux-x86_64
+            os: ubuntu-latest
+            use_cross: false
             target: x86_64-unknown-linux-gnu
           - name: Linux-arm64
+            os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          # - name: Windows-x86_64
-          #   target: x86_64-pc-windows-msvc
-          # - name: Apple-x86_64
-          #   target: x86_64-apple-darwin
-          - name: Apple-arm64
+            use_cross: true
+          - name: Darwin-arm64
+            os: macos-latest
             target: aarch64-apple-darwin
+            use_cross: false
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v3
 
@@ -48,7 +50,7 @@ jobs:
         with:
           command: build
           args: --target ${{ matrix.platform.target }} --release
-          use-cross: true
+          use-cross: ${{ matrix.platform.use_cross }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -46,12 +46,10 @@ jobs:
           args: --target ${{ matrix.platform.target }} --release
           use-cross: true
 
-      - run: |
-          cd target/${{ matrix.platform.target }}/release && \
-          ls -la
-
       - uses: actions/upload-artifact@v4
         with:
-          name: libfliptengine-${{ matrix.platform.name }}
-          path: target/**/*.(so|dll|dylib)
+          name: fliptengine-${{ matrix.platform.name }}
+          path: |
+            target/${{ matrix.platform.target }}/release/libfliptengine.*
+            target/${{ matrix.platform.target }}/release/flipt_engine.h
           retention-days: 5

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -1,0 +1,44 @@
+name: Build Rust Engine
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform:
+          - name: Linux-x86_64
+            os: [ubuntu-latest]
+            target: [x86_64-unknown-linux-gnu]
+          - name: Linux-armv7
+            os: [ubuntu-latest]
+            target: [armv7-unknown-linux-gnueabihf]
+
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.platform.target }}
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target ${{ matrix.platform.target }} --release
+          use-cross: true
+
+      - uses: actions/upload-artifact@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: libfliptengine-${{ matrix.platform.name }}
+          path: target/${{ matrix.platform.target }}/release/*.(so|dll|dylib|h)
+          retention-days: 5

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -14,9 +14,9 @@ jobs:
           - name: Linux-x86_64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - name: Linux-armv7
+          - name: Linux-arm64
             os: ubuntu-latest
-            target: armv7-unknown-linux-gnueabihf
+            target: aarch64-unknown-linux-gnu
 
     runs-on: ${{ matrix.platform.os }}
     steps:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -12,13 +12,17 @@ jobs:
       matrix:
         platform:
           - name: Linux-x86_64
-            os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - name: Linux-arm64
-            os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+          # - name: Windows-x86_64
+          #   target: x86_64-pc-windows-msvc
+          # - name: Apple-x86_64
+          #   target: x86_64-apple-darwin
+          - name: Apple-arm64
+            target: aarch64-apple-darwin
 
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -36,6 +36,9 @@ jobs:
           args: --target ${{ matrix.platform.target }} --release
           use-cross: true
 
+      - run: |
+          tree
+
       - uses: actions/upload-artifact@v4
         with:
           name: libfliptengine-${{ matrix.platform.name }}

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -46,6 +46,10 @@ jobs:
           args: --target ${{ matrix.platform.target }} --release
           use-cross: true
 
+      - run: |
+          cd target/${{ matrix.platform.target }}/release && \
+          ls -la
+
       - uses: actions/upload-artifact@v4
         with:
           name: libfliptengine-${{ matrix.platform.name }}

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -39,5 +39,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: libfliptengine-${{ matrix.platform.name }}
-          path: target/${{ matrix.platform.target }}/release/*.(so|dll|dylib|h)
+          path: target/release/*.(so|dll|dylib|h)
           retention-days: 5

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -49,5 +49,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: libfliptengine-${{ matrix.platform.name }}
-          path: target/release/*/release/*.(so|dll|dylib|h)
+          path: target/${{ matrix.platform.target}}/release/*.(so|dll|dylib)
           retention-days: 5

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -49,5 +49,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: libfliptengine-${{ matrix.platform.name }}
-          path: target/release/${{ matrix.platform.target}}/release/*.(so|dll|dylib|h)
+          path: target/release/*/release/*.(so|dll|dylib|h)
           retention-days: 5

--- a/.github/workflows/test-engine.yml
+++ b/.github/workflows/test-engine.yml
@@ -1,4 +1,4 @@
-name: Rust Engine
+name: Lint/Test Rust Engine
 on:
   push:
     branches:

--- a/flipt-engine/Cargo.toml
+++ b/flipt-engine/Cargo.toml
@@ -16,6 +16,7 @@ crc32fast = "1.3.2"
 chrono = { version = "0.4.31", features = ["serde", "rustc-serialize"] }
 futures = "0.3"
 thiserror = "1.0.50"
+openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
 cbindgen = "0.26.0"

--- a/go.work.sum
+++ b/go.work.sum
@@ -145,13 +145,14 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/urfave/cli/v2 v2.24.4 h1:0gyJJEBYtCV87zI/x2nZCPyDxD51K6xM8SkwjHFCNEU=
 github.com/urfave/cli/v2 v2.24.4/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=


### PR DESCRIPTION
getting cross compiliation/packaging of engine for multiple architectures

currently, this builds and zips up the engine for the following os/architectures:
- linux/x86_64
- linux/arm64
- mac/arm64

The plan is to integrate this with #35 or similar so that the process is

- use https://github.com/softprops/action-gh-release or release please to create release
- this workflow will then build the lib for the various architectures and upload them to the new release
- we'll then have another workflow download these uploaded zip files and package each of the clients in preparation for publishing
