### PR TITLE
feat(breaking): update node client to use close method instead of freeEngine

### DIFF
--- a/flipt-client-node/README.md
+++ b/flipt-client-node/README.md
@@ -83,8 +83,8 @@ console.log(variant);
 
 Since TypeScript/JavaScript is a garbage collected language there is no concept of "freeing" memory. We have to allocate memory for the engine through the `initialize_engine` FFI call.
 
-Make sure to call the `freeEngine` method on the `FliptEvaluationClient` class once you are done using it.
+Make sure to call the `close` method on the `FliptEvaluationClient` class once you are done using it.
 
 ```typescript
-fliptEvaluationClient.freeEngine();
+fliptEvaluationClient.close();
 ```

--- a/flipt-client-node/src/evaluation.test.ts
+++ b/flipt-client-node/src/evaluation.test.ts
@@ -32,7 +32,7 @@ test('variant', () => {
     expect(variant.result.segment_keys).toContain('segment1');
     expect(variant.result.variant_key).toContain('variant1');
   } finally {
-    if (client) client.freeEngine();
+    if (client) client.close();
   }
 });
 
@@ -54,7 +54,7 @@ test('boolean', () => {
     expect(boolean.result.enabled).toEqual(true);
     expect(boolean.result.reason).toEqual('MATCH_EVALUATION_REASON');
   } finally {
-    if (client) client.freeEngine();
+    if (client) client.close();
   }
 });
 
@@ -75,7 +75,7 @@ test('variant failure', () => {
       'invalid request: failed to get flag information default/nonexistent'
     );
   } finally {
-    if (client) client.freeEngine();
+    if (client) client.close();
   }
 });
 
@@ -96,6 +96,6 @@ test('boolean failure', () => {
       'invalid request: failed to get flag information default/nonexistent'
     );
   } finally {
-    if (client) client.freeEngine();
+    if (client) client.close();
   }
 });

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -101,7 +101,7 @@ export class FliptEvaluationClient {
     return booleanResult;
   }
 
-  public freeEngine() {
+  public close() {
     engineLib.destroy_engine(this.engine);
   }
 }


### PR DESCRIPTION
I think this reads nicer, as at the end of the day, the user shouldnt really have to know about the 'engine' under the hood