### PR TITLE
Build/Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ __pycache__/
 node_modules/
 
 .DS_Store
+tmp

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ ruby: build ## Build the ruby client gem
 clean: ## Clean up build artifacts
 	rm -rf target
 	rm -rf flipt-client-go/$(LIB).* flipt-client-go/$(HEADER)
-	rm -rf flipt-client-node/ext/$(LIB).*
+	rm -rf flipt-client-node/ext/$(LIB).* flipt-client-node/ext/$(HEADER)
 	rm -rf flipt-client-node/*.tgz
 	rm -rf flipt-client-node/dist
-	rm -rf flipt-client-python/ext/$(LIB).*
+	rm -rf flipt-client-python/ext/$(LIB).* flipt-client-python/ext/$(HEADER)
 	rm -rf flipt-client-python/dist
-	rm -rf flipt-client-ruby/lib/ext/$(LIB).*
+	rm -rf flipt-client-ruby/lib/ext/$(LIB).* flipt-client-ruby/lib/ext/$(HEADER)
 	rm -rf flipt-client-ruby/pkg/
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -4,34 +4,43 @@ HEADER = flipt_engine.h
 .DEFAULT_GOAL := help
 .PHONY: build go node python ruby help clean
 
+# get os and arch
+OS := $(shell uname -s | tr A-Z a-z)
+ARCH := $(shell uname -m | tr A-Z a-z)
+
 build: ## Build the shared engine library
 	cargo build --release
 
 go: build ## Build the go client package
-	cp target/release/$(LIB).* target/release/$(HEADER) flipt-client-go/ext/
+	mkdir -p flipt-client-go/ext/$(OS)_$(ARCH)
+	cp target/release/$(LIB).* flipt-client-go/ext/$(OS)_$(ARCH)/
+	cp target/release/$(HEADER) flipt-client-go/ext/
 	go install ./flipt-client-go
 
 node: build ## Build the node client package
-	cp target/release/$(LIB).* flipt-client-node/ext/
+	mkdir -p flipt-client-node/ext/${OS}_${ARCH}
+	cp target/release/$(LIB).* flipt-client-node/ext/${OS}_${ARCH}/
 	cd flipt-client-node && npm install && npm run build && npm pack
 
 python: build ## Build the python client package
-	cp target/release/$(LIB).* flipt-client-python/ext/
+	mkdir -p flipt-client-python/ext/${OS}_${ARCH}
+	cp target/release/$(LIB).* flipt-client-python/ext/${OS}_${ARCH}/
 	cd flipt-client-python && poetry build
 
 ruby: build ## Build the ruby client gem
-	cp target/release/$(LIB).* flipt-client-ruby/lib/ext/
+	mkdir -p flipt-client-ruby/lib/ext/${OS}_${ARCH}
+	cp target/release/$(LIB).* flipt-client-ruby/lib/ext/${OS}_${ARCH}/
 	cd flipt-client-ruby && rake install
 
 clean: ## Clean up build artifacts
 	rm -rf target
-	rm -rf flipt-client-go/$(LIB).* flipt-client-go/$(HEADER)
-	rm -rf flipt-client-node/ext/$(LIB).* flipt-client-node/ext/$(HEADER)
+	rm -rf flipt-client-go/ext/$(OS)_$(ARCH)/$(LIB).* flipt-client-go/ext/$(HEADER)
+	rm -rf flipt-client-node/ext/$(OS)_$(ARCH)/$(LIB).*
 	rm -rf flipt-client-node/*.tgz
 	rm -rf flipt-client-node/dist
-	rm -rf flipt-client-python/ext/$(LIB).* flipt-client-python/ext/$(HEADER)
+	rm -rf flipt-client-python/ext/$(OS)_$(ARCH)/$(LIB).*
 	rm -rf flipt-client-python/dist
-	rm -rf flipt-client-ruby/lib/ext/$(LIB).* flipt-client-ruby/lib/ext/$(HEADER)
+	rm -rf flipt-client-ruby/lib/ext/$(OS)_$(ARCH)/$(LIB).*
 	rm -rf flipt-client-ruby/pkg/
 
 help:

--- a/build/go.mod
+++ b/build/go.mod
@@ -1,0 +1,3 @@
+module go.flipt.io/flipt/client-sdks/build
+
+go 1.21.3

--- a/build/main.go
+++ b/build/main.go
@@ -5,7 +5,10 @@ import (
 	"os"
 
 	"dagger.io/dagger"
+	"golang.org/x/sync/errgroup"
 )
+
+var sema = make(chan struct{}, 5)
 
 func main() {
 	err := run()
@@ -13,6 +16,8 @@ func main() {
 		panic(err)
 	}
 }
+
+type buildFn func(context.Context, *dagger.Client, *dagger.Directory) error
 
 func run() error {
 	ctx := context.Background()
@@ -24,17 +29,44 @@ func run() error {
 
 	defer client.Close()
 
-	hostDirectory := client.Host().Directory(".", dagger.HostDirectoryOpts{
+	dir := client.Host().Directory(".", dagger.HostDirectoryOpts{
 		Exclude: []string{"diagrams/", "build/", "test/"},
 	})
 
-	_, err = client.Container().From("python:3.11-bookworm").
+	var g errgroup.Group
+
+	for _, fn := range []buildFn{
+		buildPython,
+	} {
+		fn := fn
+		g.Go(take(func() error {
+			return fn(ctx, client, dir)
+		}))
+	}
+
+	return g.Wait()
+}
+
+func take(fn func() error) func() error {
+	return func() error {
+		// insert into semaphore channel to maintain
+		// a max concurrency
+		sema <- struct{}{}
+		defer func() { <-sema }()
+
+		return fn()
+	}
+}
+
+func buildPython(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) error {
+	_, err := client.Container().From("python:3.11-bookworm").
 		WithExec([]string{"pip", "install", "poetry==1.7.0"}).
 		WithDirectory("/app", hostDirectory.Directory("flipt-client-python")).
 		WithDirectory("/app/ext", hostDirectory.Directory("tmp")).
 		WithWorkdir("/app").
-		WithExec([]string{"ls", "-la", "/app/ext"}).
-		WithExec([]string{"poetry", "install", "--no-dev"}).
+		WithExec([]string{"poetry", "config", "installer.parallel", "false"}).
+		WithExec([]string{"poetry", "install", "-v"}).
+		WithExec([]string{"poetry", "build", "-v"}).
 		Sync(ctx)
 
 	return err

--- a/build/main.go
+++ b/build/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	err := run()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		return err
+	}
+
+	defer client.Close()
+
+	hostDirectory := client.Host().Directory(".", dagger.HostDirectoryOpts{
+		Exclude: []string{"diagrams/", "build/", "test/"},
+	})
+
+	_, err = client.Container().From("python:3.11-bookworm").
+		WithExec([]string{"pip", "install", "poetry==1.7.0"}).
+		WithDirectory("/app", hostDirectory.Directory("flipt-client-python")).
+		WithDirectory("/app/ext", hostDirectory.Directory("tmp")).
+		WithWorkdir("/app").
+		WithExec([]string{"ls", "-la", "/app/ext"}).
+		WithExec([]string{"poetry", "install", "--no-dev"}).
+		Sync(ctx)
+
+	return err
+}

--- a/flipt-client-go/README.md
+++ b/flipt-client-go/README.md
@@ -16,7 +16,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 ### Automated Build
 
-1. Build and copy the dynamic library to the `flipt-client-go/ext` directory.
+1. Build and copy the dynamic library to the `flipt-client-go/ext` directory for your platform. You can do this by running the following command from the root of the repository:
 
     ```bash
     make go
@@ -32,7 +32,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 This should generate a `target/` directory in the root of this repository, which contains the dynamically linked library built for your platform.
 
-2. You'll need to copy the dynamic library to the `flipt-client-go/ext` directory. This is a temporary solution until we can figure out a better way to package the libraries with the module.
+2. You'll need to copy the dynamic library to the `flipt-client-go/ext/$OS_$ARCH/` directory. This is a temporary solution until we can figure out a better way to package the libraries with the module.
 
 The `path/to/lib` will be the path to the dynamic library which will have the following paths depending on your platform.
 

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -1,7 +1,9 @@
 package evaluation
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/ext/. -lfliptengine
+#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/ext/darwin_arm64/. -lfliptengine
+#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/ext/linux_arm64/. -lfliptengine
+#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/ext/linux_x86_64/. -lfliptengine
 #include <string.h>
 #include <stdlib.h>
 #include "./ext/flipt_engine.h"

--- a/flipt-client-node/README.md
+++ b/flipt-client-node/README.md
@@ -16,7 +16,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 ### Automated Build
 
-1. Build and copy the dynamic library to the `flipt-client-node` directory. You can do this by running the following command from the root of the repository:
+1. Build and copy the dynamic library to the `flipt-client-node` directory for your platform. You can do this by running the following command from the root of the repository:
 
     ```bash
     make node
@@ -38,7 +38,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 This should generate a `target/` directory in the root of this repository, which contains the dynamically linked library built for your platform.
 
-2. You'll need to copy the dynamic library to the `flipt-client-node/ext` directory. This is a temporary solution until we can figure out a better way to package the libraries with the package.
+2. You'll need to copy the dynamic library to the `flipt-client-node/ext/$OS_$ARCH/` directory. This is a temporary solution until we can figure out a better way to package the libraries with the package.
 
 The `path/to/lib` will be the path to the dynamic library which will have the following paths depending on your platform.
 

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -13,17 +13,23 @@ let libfile = '';
 
 // get absolute path to libfliptengine
 switch (os.platform()) {
-  case 'win32':
-    libfile = 'libfliptengine.dll';
-    break;
   case 'darwin':
-    libfile = 'libfliptengine.dylib';
-    break;
+    if (os.arch() === 'arm64') {
+      libfile = 'darwin_arm64/libfliptengine.dylib';
+      break;
+    }
+    throw new Error('Unsupported platform: ' + os.platform() + '/' + os.arch());
   case 'linux':
-    libfile = 'libfliptengine.so';
-    break;
+    if (os.arch() === 'arm64') {
+      libfile = 'linux_arm64/libfliptengine.so';
+      break;
+    } else if (os.arch() === 'x64') {
+      libfile = 'linux_x86_64/libfliptengine.so';
+      break;
+    }
+    throw new Error('Unsupported platform: ' + os.platform() + '/' + os.arch());
   default:
-    throw new Error('Unsupported platform: ' + os.platform());
+    throw new Error('Unsupported platform: ' + os.platform() + '/' + os.arch());
 }
 
 libfile = path.join(__dirname, '..', 'ext', libfile);

--- a/flipt-client-python/README.md
+++ b/flipt-client-python/README.md
@@ -17,7 +17,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 ### Automated Build
 
-1. Build and copy the dynamic library to the `flipt-client-python/ext` directory. This will also build and install the `flipt-client` Python package. You can do this by running the following command from the root of the repository:
+1. Build and copy the dynamic library to the `flipt-client-python/ext` directory for your platform. This will also build and install the `flipt-client` Python package. You can do this by running the following command from the root of the repository:
 
     ```bash
     make python
@@ -32,7 +32,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 This should generate a `target/` directory in the root of this repository, which contains the dynamically linked library built for your platform.
 
-2. You'll need to copy the dynamic library to the `flipt-client-python/ext` directory. This is a temporary solution until we can figure out a better way to package the libraries with the package.
+2. You'll need to copy the dynamic library to the `flipt-client-python/ext/$OS_$ARCH/` directory. This is a temporary solution until we can figure out a better way to package the libraries with the package.
 
 The `path/to/lib` will be the path to the dynamic library which will have the following paths depending on your platform.
 

--- a/flipt-client-python/flipt_client/__init__.py
+++ b/flipt-client-python/flipt_client/__init__.py
@@ -15,7 +15,7 @@ class FliptEvaluationClient:
         # get dynamic library extension for the current platform
         if platform.system() == "Darwin":
             if platform.machine() == "arm64" or platform.machine() == "aarch64":
-                libfile = "libfliptengine.darwin.arm64.dylib"
+                libfile = "darwin_arm64/libfliptengine.dylib"
             else:
                 raise Exception(
                     f"Unsupported processor: {platform.processor()}. Please use an M1 Mac."
@@ -23,9 +23,9 @@ class FliptEvaluationClient:
         elif platform.system() == "Linux":
             arch = platform.machine()
             if arch == "x86":
-                libfile = "libfliptengine.linux.x86_64.so"
+                libfile = "linux_x86_64/libfliptengine.so"
             elif arch == "arm64" or arch == "aarch64":
-                libfile = "libfliptengine.linux.arm64.so"
+                libfile = "linux_arm64/libfliptengine.so"
             else:
                 raise Exception(
                     f"Unsupported processor: {platform.processor()}. Please use an x86_64 or arm64 Linux machine."

--- a/flipt-client-python/flipt_client/__init__.py
+++ b/flipt-client-python/flipt_client/__init__.py
@@ -14,7 +14,8 @@ class FliptEvaluationClient:
     def __init__(self, namespace: str = "default", engine_opts: EngineOpts = {}):
         # get dynamic library extension for the current platform
         if platform.system() == "Darwin":
-            if platform.machine() == "arm64" or platform.machine() == "aarch64":
+            arch = platform.machine()
+            if arch == "arm64" or arch == "aarch64":
                 libfile = "darwin_arm64/libfliptengine.dylib"
             else:
                 raise Exception(

--- a/flipt-client-python/flipt_client/__init__.py
+++ b/flipt-client-python/flipt_client/__init__.py
@@ -13,12 +13,23 @@ from .models import (
 class FliptEvaluationClient:
     def __init__(self, namespace: str = "default", engine_opts: EngineOpts = {}):
         # get dynamic library extension for the current platform
-        if platform.system() == "Windows":
-            libfile = "fliptengine.dll"
-        elif platform.system() == "Darwin":
-            libfile = "libfliptengine.dylib"
+        if platform.system() == "Darwin":
+            if platform.machine() == "arm64" or platform.machine() == "aarch64":
+                libfile = "libfliptengine.darwin.arm64.dylib"
+            else:
+                raise Exception(
+                    f"Unsupported processor: {platform.processor()}. Please use an M1 Mac."
+                )
         elif platform.system() == "Linux":
-            libfile = "libfliptengine.so"
+            arch = platform.machine()
+            if arch == "x86":
+                libfile = "libfliptengine.linux.x86_64.so"
+            elif arch == "arm64" or arch == "aarch64":
+                libfile = "libfliptengine.linux.arm64.so"
+            else:
+                raise Exception(
+                    f"Unsupported processor: {platform.processor()}. Please use an x86_64 or arm64 Linux machine."
+                )
         else:
             raise Exception(f"Unsupported platform: {platform.system()}.")
 

--- a/flipt-client-ruby/README.md
+++ b/flipt-client-ruby/README.md
@@ -16,7 +16,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 ### Automated Build
 
-1. Build and copy the dynamic library to the `flipt-client-ruby/lib/ext` directory. This will also build and install the `flipt_client` gem on your local machine. You can do this by running the following command from the root of the repository:
+1. Build and copy the dynamic library to the `flipt-client-ruby/lib/ext` directory for yoru platform. This will also build and install the `flipt_client` gem on your local machine. You can do this by running the following command from the root of the repository:
 
     ```bash
     make ruby
@@ -32,7 +32,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 This should generate a `target/` directory in the root of this repository, which contains the dynamically linked library built for your platform.
 
-2. You'll need to copy the dynamic library to the `flipt-client-ruby/lib/ext` directory. This is a temporary solution until we can figure out a better way to package the libraries with the gem.
+2. You'll need to copy the dynamic library to the `flipt-client-ruby/lib/ext/$OS_$ARCH/` directory. This is a temporary solution until we can figure out a better way to package the libraries with the gem.
 
 The `path/to/lib` will be the path to the dynamic library which will have the following paths depending on your platform.
 

--- a/flipt-client-ruby/README.md
+++ b/flipt-client-ruby/README.md
@@ -16,7 +16,7 @@ The dynamic library will contain the functionality necessary for the client to m
 
 ### Automated Build
 
-1. Build and copy the dynamic library to the `flipt-client-ruby/lib/ext` directory for yoru platform. This will also build and install the `flipt_client` gem on your local machine. You can do this by running the following command from the root of the repository:
+1. Build and copy the dynamic library to the `flipt-client-ruby/lib/ext` directory for your platform. This will also build and install the `flipt_client` gem on your local machine. You can do this by running the following command from the root of the repository:
 
     ```bash
     make ruby

--- a/flipt-client-ruby/lib/evaluation.rb
+++ b/flipt-client-ruby/lib/evaluation.rb
@@ -10,18 +10,18 @@ module Flipt
   class EvaluationClient
     extend FFI::Library
 
-    FLIPTENGINE = 'ext/libfliptengine'
+    FLIPTENGINE = 'libfliptengine'
 
     def self.libfile
-      case RbConfig::CONFIG['host_os']
-      when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
-        "#{FLIPTENGINE}.dll"
-      when /darwin|mac os/
-        "#{FLIPTENGINE}.dylib"
-      when /linux/
-        "#{FLIPTENGINE}.so"
+      case RbConfig::CONFIG['arch']
+      when /arm64-darwin/
+        "ext/darwin_arm64/#{FLIPTENGINE}.dylib"
+      when /arm64-linux|aarch64-linux/
+        "ext/linux_arm64/#{FLIPTENGINE}.so"
+      when /x86_64-linux/
+        "ext/linux_x86_64/#{FLIPTENGINE}.so"
       else
-        raise "unsupported platform #{RbConfig::CONFIG['host_os']}"
+        raise "unsupported platform #{RbConfig::CONFIG['arch']}"
       end
     end
 

--- a/flipt-engine/Cargo.toml
+++ b/flipt-engine/Cargo.toml
@@ -27,3 +27,6 @@ mockall = "0.11.4"
 [lib]
 name = "fliptengine"
 crate-type = ["rlib", "dylib"]
+
+[profile.release]
+strip = true

--- a/go.work
+++ b/go.work
@@ -3,4 +3,5 @@ go 1.21.3
 use (
 	./flipt-client-go
 	./test
+	./build
 )

--- a/test/main.go
+++ b/test/main.go
@@ -22,7 +22,7 @@ var (
 		"node":   nodeTests,
 		"ruby":   rubyTests,
 	}
-	sema = make(chan struct{}, len(languageToFn))
+	sema = make(chan struct{}, 5)
 )
 
 type testArgs struct {
@@ -81,17 +81,14 @@ func run() error {
 
 	var g errgroup.Group
 
-	for _, testFn := range tests {
-		testFn := testFn
-
+	for _, fn := range tests {
+		fn := fn
 		g.Go(take(func() error {
-			return testFn(ctx, client, flipt, args)
+			return fn(ctx, client, flipt, args)
 		}))
 	}
 
-	err = g.Wait()
-
-	return err
+	return g.Wait()
 }
 
 func take(fn func() error) func() error {

--- a/test/main.go
+++ b/test/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"maps"
 	"os"
+	"runtime"
 	"strings"
 
 	"dagger.io/dagger"
@@ -24,7 +25,14 @@ var (
 	sema = make(chan struct{}, len(languageToFn))
 )
 
-type integrationTestFn func(context.Context, *dagger.Client, *dagger.Container, *dagger.File, *dagger.File, *dagger.Directory) error
+type testArgs struct {
+	arch       string
+	libFile    *dagger.File
+	headerFile *dagger.File
+	hostDir    *dagger.Directory
+}
+
+type integrationTestFn func(context.Context, *dagger.Client, *dagger.Container, testArgs) error
 
 func init() {
 	flag.StringVar(&languages, "languages", "", "comma separated list of which language(s) to run integration tests for")
@@ -59,17 +67,17 @@ func run() error {
 
 	ctx := context.Background()
 
-	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
 	dir := client.Host().Directory(".", dagger.HostDirectoryOpts{
-		Exclude: []string{"diagrams/"},
+		Exclude: []string{"diagrams/", "build/", "tmp/"},
 	})
 
-	flipt, dynamicLibrary, headerFile := getTestDependencies(ctx, client, dir)
+	flipt, args := getTestDependencies(ctx, client, dir)
 
 	var g errgroup.Group
 
@@ -77,7 +85,7 @@ func run() error {
 		testFn := testFn
 
 		g.Go(take(func() error {
-			return testFn(ctx, client, flipt, dynamicLibrary, headerFile, dir)
+			return testFn(ctx, client, flipt, args)
 		}))
 	}
 
@@ -99,7 +107,12 @@ func take(fn func() error) func() error {
 
 // getTestDependencies builds the dynamic library for the Rust core, and the Flipt container for the client libraries to run
 // their tests against.
-func getTestDependencies(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) (*dagger.Container, *dagger.File, *dagger.File) {
+func getTestDependencies(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) (*dagger.Container, testArgs) {
+	arch := "x86_64"
+	if strings.Contains(runtime.GOARCH, "arm64") || strings.Contains(runtime.GOARCH, "aarch64") {
+		arch = "arm64"
+	}
+
 	// Dynamic Library
 	rust := client.Container().From("rust:1.73.0-bookworm").
 		WithWorkdir("/app").
@@ -121,16 +134,22 @@ func getTestDependencies(ctx context.Context, client *dagger.Client, hostDirecto
 		WithEnvVariable("FLIPT_AUTHENTICATION_REQUIRED", "1").
 		WithExposedPort(8080)
 
-	return flipt, rust.File("/app/target/release/libfliptengine.so"), rust.File("/app/target/release/flipt_engine.h")
+	return flipt, testArgs{
+		arch:       arch,
+		libFile:    rust.File("/app/target/release/libfliptengine.so"),
+		headerFile: rust.File("/app/target/release/flipt_engine.h"),
+		hostDir:    hostDirectory,
+	}
 }
 
 // pythonTests runs the python integration test suite against a container running Flipt.
-func pythonTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, dynamicLibrary *dagger.File, _ *dagger.File, hostDirectory *dagger.Directory) error {
+func pythonTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, args testArgs) error {
+
 	_, err := client.Container().From("python:3.11-bookworm").
 		WithExec([]string{"pip", "install", "poetry==1.7.0"}).
 		WithWorkdir("/app").
-		WithDirectory("/app", hostDirectory.Directory("flipt-client-python")).
-		WithFile("/app/ext/libfliptengine.so", dynamicLibrary).
+		WithDirectory("/app", args.hostDir.Directory("flipt-client-python")).
+		WithFile(fmt.Sprintf("/app/ext/libfliptengine.linux.%s.so", args.arch), args.libFile).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -142,14 +161,14 @@ func pythonTests(ctx context.Context, client *dagger.Client, flipt *dagger.Conta
 }
 
 // goTests runs the golang integration test suite against a container running Flipt.
-func goTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, dynamicLibrary *dagger.File, headerFile *dagger.File, hostDirectory *dagger.Directory) error {
+func goTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, args testArgs) error {
 	_, err := client.Container().From("golang:1.21.3-bookworm").
 		WithExec([]string{"apt-get", "update"}).
 		WithExec([]string{"apt-get", "-y", "install", "build-essential"}).
 		WithWorkdir("/app").
-		WithDirectory("/app", hostDirectory.Directory("flipt-client-go")).
-		WithFile("/app/ext/libfliptengine.so", dynamicLibrary).
-		WithFile("/app/ext/flipt_engine.h", headerFile).
+		WithDirectory("/app", args.hostDir.Directory("flipt-client-go")).
+		WithFile("/app/ext/libfliptengine.so", args.libFile).
+		WithFile("/app/ext/flipt_engine.h", args.headerFile).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -165,15 +184,15 @@ func goTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container
 }
 
 // nodeTests runs the node integration test suite against a container running Flipt.
-func nodeTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, dynamicLibrary *dagger.File, _ *dagger.File, hostDirectory *dagger.Directory) error {
+func nodeTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, args testArgs) error {
 	_, err := client.Container().From("node:21.2-bookworm").
 		WithWorkdir("/app").
 		// The node_modules should never be version controlled, but we will exclude it here
 		// just to be safe.
-		WithDirectory("/app", hostDirectory.Directory("flipt-client-node"), dagger.ContainerWithDirectoryOpts{
+		WithDirectory("/app", args.hostDir.Directory("flipt-client-node"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{"./node_modules/"},
 		}).
-		WithFile("/app/ext/libfliptengine.so", dynamicLibrary).
+		WithFile("/app/ext/libfliptengine.so", args.libFile).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -185,11 +204,11 @@ func nodeTests(ctx context.Context, client *dagger.Client, flipt *dagger.Contain
 }
 
 // rubyTests runs the ruby integration test suite against a container running Flipt.
-func rubyTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, dynamicLibrary *dagger.File, _ *dagger.File, hostDirectory *dagger.Directory) error {
+func rubyTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container, args testArgs) error {
 	_, err := client.Container().From("ruby:3.1-bookworm").
 		WithWorkdir("/app").
-		WithDirectory("/app", hostDirectory.Directory("flipt-client-ruby")).
-		WithFile("/app/lib/ext/libfliptengine.so", dynamicLibrary).
+		WithDirectory("/app", args.hostDir.Directory("flipt-client-ruby")).
+		WithFile("/app/lib/ext/libfliptengine.so", args.libFile).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").

--- a/test/main.go
+++ b/test/main.go
@@ -146,7 +146,7 @@ func pythonTests(ctx context.Context, client *dagger.Client, flipt *dagger.Conta
 		WithExec([]string{"pip", "install", "poetry==1.7.0"}).
 		WithWorkdir("/app").
 		WithDirectory("/app", args.hostDir.Directory("flipt-client-python")).
-		WithFile(fmt.Sprintf("/app/ext/libfliptengine.linux.%s.so", args.arch), args.libFile).
+		WithFile(fmt.Sprintf("/app/ext/linux_%s/libfliptengine.so", args.arch), args.libFile).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -164,7 +164,7 @@ func goTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container
 		WithExec([]string{"apt-get", "-y", "install", "build-essential"}).
 		WithWorkdir("/app").
 		WithDirectory("/app", args.hostDir.Directory("flipt-client-go")).
-		WithFile("/app/ext/libfliptengine.so", args.libFile).
+		WithFile(fmt.Sprintf("/app/ext/linux_%s/libfliptengine.so", args.arch), args.libFile).
 		WithFile("/app/ext/flipt_engine.h", args.headerFile).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
@@ -172,7 +172,7 @@ func goTests(ctx context.Context, client *dagger.Client, flipt *dagger.Container
 		// Since the dynamic library is being sourced from a "non-standard location" we can
 		// modify the LD_LIBRARY_PATH variable to inform the linker different locations for
 		// dynamic libraries.
-		WithEnvVariable("LD_LIBRARY_PATH", "/app/ext:$LD_LIBRARY_PATH").
+		WithEnvVariable("LD_LIBRARY_PATH", fmt.Sprintf("/app/ext/linux_%s:$LD_LIBRARY_PATH", args.arch)).
 		WithExec([]string{"go", "mod", "download"}).
 		WithExec([]string{"go", "test", "./..."}).
 		Sync(ctx)
@@ -189,7 +189,7 @@ func nodeTests(ctx context.Context, client *dagger.Client, flipt *dagger.Contain
 		WithDirectory("/app", args.hostDir.Directory("flipt-client-node"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{"./node_modules/"},
 		}).
-		WithFile("/app/ext/libfliptengine.so", args.libFile).
+		WithFile(fmt.Sprintf("/app/ext/linux_%s/libfliptengine.so", args.arch), args.libFile).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -205,7 +205,7 @@ func rubyTests(ctx context.Context, client *dagger.Client, flipt *dagger.Contain
 	_, err := client.Container().From("ruby:3.1-bookworm").
 		WithWorkdir("/app").
 		WithDirectory("/app", args.hostDir.Directory("flipt-client-ruby")).
-		WithFile("/app/lib/ext/libfliptengine.so", args.libFile).
+		WithFile(fmt.Sprintf("/app/lib/ext/linux_%s/libfliptengine.so", args.arch), args.libFile).
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").


### PR DESCRIPTION
Re: #38 

First steps in packaging natively per ecosystem

This creates a dagger pipeline to build packages for each ecosystem.

It currently assumes that the built libraries for each arch/platform exist locally in the following structure

```
tmp
├── darwin_arm64
│   └── libfliptengine.dylib
├── flipt_engine.h
├── linux_arm64
│   └── libfliptengine.so
└── linux_x84_64
    └── libfliptengine.so
```

This will be adjusted once we update this pipeline to run in GH Actions and in combo with #33 

This also updates the tests to depend on these files being in the above mentioned structure and drops windows support for now

## TODO

- [x] Figure out what to do with the Makefile now that the output paths have changed for the lib
- [x] Update per client readmes