### PR TITLE
chore: setup build/push workflow for ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ node_modules/
 
 .DS_Store
 tmp
+.envrc

--- a/build/main.go
+++ b/build/main.go
@@ -2,24 +2,63 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
+	"log"
+	"maps"
 	"os"
+	"strings"
 
 	"dagger.io/dagger"
 	"golang.org/x/sync/errgroup"
 )
 
-var sema = make(chan struct{}, 5)
+var (
+	languages    string
+	push         bool
+	languageToFn = map[string]buildFn{
+		"python": pythonBuild,
+		"go":     goBuild,
+		"node":   nodeBuild,
+		"ruby":   rubyBuild,
+	}
+	sema = make(chan struct{}, 5)
+)
+
+func init() {
+	flag.StringVar(&languages, "languages", "", "comma separated list of which language(s) to run integration tests for")
+	flag.BoolVar(&push, "push", false, "push built artifacts to registry")
+}
 
 func main() {
-	err := run()
-	if err != nil {
-		panic(err)
+	flag.Parse()
+
+	if err := run(); err != nil {
+		log.Fatal(err)
 	}
 }
 
 type buildFn func(context.Context, *dagger.Client, *dagger.Directory) error
 
 func run() error {
+	var tests = make(map[string]buildFn, len(languageToFn))
+
+	maps.Copy(tests, languageToFn)
+
+	if languages != "" {
+		l := strings.Split(languages, ",")
+		subset := make(map[string]buildFn, len(l))
+		for _, language := range l {
+			testFn, ok := languageToFn[language]
+			if !ok {
+				return fmt.Errorf("language %s is not supported", language)
+			}
+			subset[language] = testFn
+		}
+
+		tests = subset
+	}
+
 	ctx := context.Background()
 
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
@@ -30,17 +69,12 @@ func run() error {
 	defer client.Close()
 
 	dir := client.Host().Directory(".", dagger.HostDirectoryOpts{
-		Exclude: []string{"diagrams/", "build/", "test/"},
+		Exclude: []string{"diagrams/", "build/", "test/", ".git/"},
 	})
 
 	var g errgroup.Group
 
-	for _, fn := range []buildFn{
-		pythonBuild,
-		goBuild,
-		nodeBuild,
-		rubyBuild,
-	} {
+	for _, fn := range tests {
 		fn := fn
 		g.Go(take(func() error {
 			return fn(ctx, client, dir)
@@ -101,12 +135,35 @@ func nodeBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger
 }
 
 func rubyBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) error {
-	_, err := client.Container().From("ruby:3.1-bookworm").
+	if os.Getenv("RUBYGEMS_API_KEY") == "" {
+		return fmt.Errorf("RUBYGEMS_API_KEY is not set")
+	}
+
+	gemHostAPIKeySecret := client.SetSecret("rubygems-api-key", os.Getenv("RUBYGEMS_API_KEY"))
+
+	gemHost := os.Getenv("RUBYGEMS_HOST")
+	if gemHost == "" {
+		// TODO: relax this when we push to rubygems.org
+		return fmt.Errorf("RUBYGEMS_HOST is not set")
+	}
+
+	container := client.Container().From("ruby:3.1-bookworm").
+		WithWorkdir("/app").
 		WithDirectory("/app", hostDirectory.Directory("flipt-client-ruby")).
 		WithDirectory("/app/lib/ext", hostDirectory.Directory("tmp")).
-		WithWorkdir("/app").
 		WithExec([]string{"bundle", "install"}).
-		WithExec([]string{"bundle", "exec", "rake", "build"}).
+		WithExec([]string{"bundle", "exec", "rake", "build"})
+
+	var err error
+
+	if !push {
+		_, err = container.Sync(ctx)
+		return err
+	}
+
+	_, err = container.
+		WithSecretVariable("GEM_HOST_API_KEY", gemHostAPIKeySecret).
+		WithExec([]string{"gem", "push", "--host", gemHost, "/app/pkg/flipt_client-*.gem"}).
 		Sync(ctx)
 
 	return err

--- a/flipt-client-node/package.json
+++ b/flipt-client-node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flipt-client",
+  "name": "@flipt-io/flipt-client",
   "version": "0.0.1",
   "description": "Flipt Node Client for client-side evaluation",
   "main": "dist/index.js",

--- a/flipt-client-ruby/flipt-client-ruby.gemspec
+++ b/flipt-client-ruby/flipt-client-ruby.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative 'lib/client/version'
+require_relative 'lib/flipt_client/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'flipt_client'
-  spec.version       = Flipt::Client::VERSION
+  spec.version       = Flipt::VERSION
   spec.authors       = ['Flipt Devs']
   spec.email         = ['dev@flipt.io']
 
@@ -14,13 +14,13 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
 
-  spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  # spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.metadata['homepage_uri'] = spec.homepage
   # spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
   # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
-  spec.files = Dir.glob('{lib,spec}/**/*') + ['README.md']
+  spec.files = Dir.glob('{lib}/**/*') + ['README.md', 'flipt-client-ruby.gemspec']
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/flipt-client-ruby/lib/flipt_client.rb
+++ b/flipt-client-ruby/lib/flipt_client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'client/version'
+require 'flipt_client/version'
 require 'ffi'
 require 'json'
 

--- a/flipt-client-ruby/lib/flipt_client/version.rb
+++ b/flipt-client-ruby/lib/flipt_client/version.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 module Flipt
-  module Client
-    VERSION = '0.1.0'
-  end
+  VERSION = '0.1.0'
 end

--- a/flipt-client-ruby/spec/evaluation_spec.rb
+++ b/flipt-client-ruby/spec/evaluation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../lib/evaluation'
+require_relative '../lib/flipt_client'
 
 RSpec.describe Flipt::EvaluationClient do
   describe '#evaluate_variant' do

--- a/test/main.go
+++ b/test/main.go
@@ -74,7 +74,7 @@ func run() error {
 	defer client.Close()
 
 	dir := client.Host().Directory(".", dagger.HostDirectoryOpts{
-		Exclude: []string{"diagrams/", "build/", "tmp/"},
+		Exclude: []string{"diagrams/", "build/", "tmp/", ".git/"},
 	})
 
 	flipt, args := getTestDependencies(ctx, client, dir)


### PR DESCRIPTION
re: #38 for Ruby

- Updates build pipeline to specify specific languages
- Updates build pipeline to allow push
- Setup push to rubygems registry for Ruby

I tested this by setting up `gitea` locally and configuring it to act as the gem host: https://docs.gitea.com/usage/packages/rubygems/

This pipeline will require updating once we want to push to actual ruby gems, but its good enough for now