### PR TITLE
chore: push go module to gitea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ ruby: build ## Build the ruby client gem
 
 clean: ## Clean up build artifacts
 	rm -rf target
-	rm -rf flipt-client-go/ext/$(OS)_$(ARCH)/$(LIB).* flipt-client-go/ext/$(HEADER)
-	rm -rf flipt-client-node/ext/$(OS)_$(ARCH)/$(LIB).*
+	rm -rf flipt-client-go/ext/*
+	rm -rf flipt-client-node/ext/*
 	rm -rf flipt-client-node/*.tgz
 	rm -rf flipt-client-node/dist
-	rm -rf flipt-client-python/ext/$(OS)_$(ARCH)/$(LIB).*
+	rm -rf flipt-client-python/ext/*
 	rm -rf flipt-client-python/dist
-	rm -rf flipt-client-ruby/lib/ext/$(OS)_$(ARCH)/$(LIB).*
+	rm -rf flipt-client-ruby/lib/ext/*
 	rm -rf flipt-client-ruby/pkg/
 
 help:

--- a/build/main.go
+++ b/build/main.go
@@ -29,7 +29,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&languages, "languages", "", "comma separated list of which language(s) to run integration tests for")
+	flag.StringVar(&languages, "languages", "", "comma separated list of which language(s) to run builds for")
 	flag.BoolVar(&push, "push", false, "push built artifacts to registry")
 	flag.BoolVar(&secure, "secure", true, "use secure protocol (https) to push artifacts")
 	flag.StringVar(&version, "version", "", "version to build")
@@ -142,6 +142,7 @@ func pythonBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagg
 }
 
 func goBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) error {
+
 	if version == "" {
 		return fmt.Errorf("version is not set")
 	}


### PR DESCRIPTION
Re: #38 

Adds (private) go module push support

Note: This will probably need to change once we push to github. This will probably follow the same process that we use for our existing Go SDK.

Also need to setup the vanity import for this as well

/cc @GeorgeMac