### PR TITLE
chore: update Readme; rm rlib; strip libraries

### DIFF
--- a/.github/workflows/package-engine.yml
+++ b/.github/workflows/package-engine.yml
@@ -59,6 +59,14 @@ jobs:
           use-cross: ${{ matrix.platform.use_cross }}
 
       - run: |
+          strip -x target/${{ matrix.platform.target }}/release/libfliptengine.dylib
+        if: matrix.platform.name == 'Darwin-arm64'
+
+      - run: |
+          strip -x target/${{ matrix.platform.target }}/release/libfliptengine.so
+        if: matrix.platform.name != 'Darwin-arm64'
+
+      - run: |
           tar -czvf flipt-engine-${{ matrix.platform.name }}.tar.gz \
             target/${{ matrix.platform.target }}/release/libfliptengine.* \
             target/${{ matrix.platform.target }}/release/flipt_engine.h \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ These client-side SDKs are responsible for evaluating context and returning the 
 > [!WARNING]
 > These SDKs are currently experimental. We are looking for feedback on the design and implementation. Please open an issue if you have any feedback or questions.
 
+Check out our introductory [blog post](https://www.flipt.io/blog/new-client-side-evaluation) on these client-side SDKs.
+
 ## Architecture
 
 The client SDKs are designed to be embedded in end-user applications.

--- a/flipt-client-ruby/Gemfile.lock
+++ b/flipt-client-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flipt_client (0.1.0)
+    flipt_client (0.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/flipt-client-ruby/loadtest.rb
+++ b/flipt-client-ruby/loadtest.rb
@@ -1,4 +1,4 @@
-require "../flipt-client-ruby/lib/evaluation"
+require_relative "lib/flipt_client"
 
 # note: this script assumes you have built the flipt-client Ruby gem locally via the instructions in the README
 # and that the flag "my-feature" exists in the default namespace

--- a/flipt-engine/Cargo.toml
+++ b/flipt-engine/Cargo.toml
@@ -26,7 +26,7 @@ mockall = "0.11.4"
 
 [lib]
 name = "fliptengine"
-crate-type = ["dylib"]
+crate-type = ["rlib", "dylib"]
 
 [profile.release]
 strip = true

--- a/flipt-engine/Cargo.toml
+++ b/flipt-engine/Cargo.toml
@@ -26,7 +26,7 @@ mockall = "0.11.4"
 
 [lib]
 name = "fliptengine"
-crate-type = ["rlib", "dylib"]
+crate-type = ["dylib"]
 
 [profile.release]
 strip = true


### PR DESCRIPTION
s- small readme update
- ~~dont build `rlib` (Rust shared library) for now~~ see: https://github.com/rust-lang/rust/issues/19680
- strip dlls of build/debug symbols for smaller size

Saves about 2MB on MacOS, havent tried on linux yet

```
-rw-r--r--  1 markphelps  staff   780B Dec 26 19:30 libfliptengine.d
-rwxr-xr-x  1 markphelps  staff    10M Dec 26 19:30 libfliptengine.dylib
workspace/client-sdks - [readme-rlib●] » strip -x flipt-client-ruby/lib/ext/darwin_arm64/libfliptengine.dylib
workspace/client-sdks - [readme-rlib●] » ls -lah flipt-client-ruby/lib/ext/darwin_arm64/
total 17024
drwxr-xr-x  4 markphelps  staff   128B Dec 26 19:30 .
drwxr-xr-x  4 markphelps  staff   128B Dec 26 19:27 ..
-rw-r--r--  1 markphelps  staff   780B Dec 26 19:30 libfliptengine.d
-rwxr-xr-x  1 markphelps  staff   8.3M Dec 26 19:30 libfliptengine.dylib
```