### PR TITLE
chore: update go sdk godocs; add licenses to all

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -18,8 +18,6 @@ import (
 var (
 	languages    string
 	push         bool
-	secure       bool
-	protocol     string = "https"
 	tag          string
 	languageToFn = map[string]buildFn{
 		"python": pythonBuild,
@@ -33,16 +31,11 @@ var (
 func init() {
 	flag.StringVar(&languages, "languages", "", "comma separated list of which language(s) to run builds for")
 	flag.BoolVar(&push, "push", false, "push built artifacts to registry")
-	flag.BoolVar(&secure, "secure", true, "use secure protocol (https) to push artifacts")
 	flag.StringVar(&tag, "tag", "", "tag to use for release")
 }
 
 func main() {
 	flag.Parse()
-
-	if !secure {
-		protocol = "http"
-	}
 
 	if err := run(); err != nil {
 		log.Fatal(err)
@@ -183,7 +176,7 @@ func goBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger.D
 		WithEnvVariable("FILTER_BRANCH_SQUELCH_WARNING", "1").
 		WithExec([]string{"git", "filter-branch", "-f", "--prune-empty",
 			"--subdirectory-filter", "flipt-client-go",
-			"--tree-filter", "cp -r /tmp/ext .",
+			"--index-filter", "cp -r /tmp/ext .",
 			"--", tag})
 
 	if !push {

--- a/flipt-client-go/LICENSE
+++ b/flipt-client-go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Flipt Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -24,7 +24,7 @@ type Client struct {
 	updateInterval int
 }
 
-// NewClient constructs an Client.
+// NewClient constructs a Client.
 func NewClient(opts ...clientOption) (*Client, error) {
 	client := &Client{
 		namespace: "default",
@@ -63,7 +63,7 @@ func NewClient(opts ...clientOption) (*Client, error) {
 	return client, nil
 }
 
-// clientOption adds additional configuraiton for Client parameters
+// clientOption adds additional configuraition for Client parameters
 type clientOption func(*Client)
 
 // WithNamespace allows for specifying which namespace the clients wants to make evaluations from.
@@ -120,7 +120,7 @@ func (e *Client) EvaluateVariant(_ context.Context, flagKey, entityID string, ev
 	return vr, nil
 }
 
-// Boolean makes an evaluation on a boolean flag.
+// EvaluateBoolean makes an evaluation on a boolean flag.
 func (e *Client) EvaluateBoolean(_ context.Context, flagKey, entityID string, evalContext map[string]string) (*BooleanResult, error) {
 	ereq, err := json.Marshal(evaluationRequest{
 		NamespaceKey: e.namespace,

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -63,7 +63,7 @@ func NewClient(opts ...clientOption) (*Client, error) {
 	return client, nil
 }
 
-// clientOption adds additional configuraition for Client parameters
+// clientOption adds additional configuration for Client parameters
 type clientOption func(*Client)
 
 // WithNamespace allows for specifying which namespace the clients wants to make evaluations from.

--- a/flipt-client-node/LICENSE
+++ b/flipt-client-node/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Flipt Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flipt-client-python/LICENSE
+++ b/flipt-client-python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Flipt Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flipt-client-ruby/LICENSE
+++ b/flipt-client-ruby/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Flipt Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
- rm unused flags from build script
- update godocs in go sdk
- copy licenses to each sdk
- use `index-filter` when copying go SDK to own repo as should be faster