### PR TITLE
fix: instead of using empty dictionary use actual EngineOpts instance

### DIFF
--- a/.github/workflows/test-engine.yml
+++ b/.github/workflows/test-engine.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.75.0
           override: true
 
       - name: Test

--- a/flipt-client-python/flipt_client/__init__.py
+++ b/flipt-client-python/flipt_client/__init__.py
@@ -11,7 +11,9 @@ from .models import (
 
 
 class FliptEvaluationClient:
-    def __init__(self, namespace: str = "default", engine_opts: EngineOpts = {}):
+    def __init__(
+        self, namespace: str = "default", engine_opts: EngineOpts = EngineOpts()
+    ):
         # get dynamic library extension for the current platform
         if platform.system() == "Darwin":
             arch = platform.machine()

--- a/flipt-engine/src/error/mod.rs
+++ b/flipt-engine/src/error/mod.rs
@@ -9,7 +9,7 @@ pub enum Error {
     #[error("invalid request: {0}")]
     InvalidRequest(String),
     #[error("server error: {0}")]
-    ServerError(String),
+    Server(String),
     #[error("unknown error: {0}")]
     Unknown(String),
 }

--- a/flipt-engine/src/parser/mod.rs
+++ b/flipt-engine/src/parser/mod.rs
@@ -57,17 +57,12 @@ impl Parser for HTTPParser {
             .send()
         {
             Ok(resp) => resp,
-            Err(e) => return Err(Error::ServerError(format!("failed to make request: {}", e))),
+            Err(e) => return Err(Error::Server(format!("failed to make request: {}", e))),
         };
 
         let response_text = match response.text() {
             Ok(t) => t,
-            Err(e) => {
-                return Err(Error::ServerError(format!(
-                    "failed to get response body: {}",
-                    e
-                )))
-            }
+            Err(e) => return Err(Error::Server(format!("failed to get response body: {}", e))),
         };
 
         let document: source::Document = match serde_json::from_str(&response_text) {


### PR DESCRIPTION
We are using an empty dictionary for the default value of `EngineOpts` currently which will cause the call to the FFI layer to fail if the user doesn't actual provide real values for `EngineOpts`, and the default is used.

This change uses an actual instance of `EngineOpts` as the default.