### PR TITLE
fix: dont wipe out snapshot if error in parser

### DIFF
--- a/flipt-engine/examples/evaluation.rs
+++ b/flipt-engine/examples/evaluation.rs
@@ -9,7 +9,8 @@ fn main() {
     let evaluator = Evaluator::new_snapshot_evaluator(
         vec!["default".into()],
         HTTPParser::new("http://localhost:8080", Some("secret")),
-    );
+    )
+    .unwrap();
 
     let eng = fliptengine::Engine::new(evaluator, Default::default());
     let mut context: HashMap<String, String> = HashMap::new();

--- a/flipt-engine/lib/evaluation/src/lib.rs
+++ b/flipt-engine/lib/evaluation/src/lib.rs
@@ -114,14 +114,21 @@ impl<P> Evaluator<P, Snapshot>
 where
     P: Parser + Send,
 {
-    pub fn new_snapshot_evaluator(namespaces: Vec<String>, parser: P) -> Self {
-        let snap = Snapshot::build(&namespaces, &parser);
-        Evaluator::new(namespaces, parser, snap)
+    pub fn new_snapshot_evaluator(namespaces: Vec<String>, parser: P) -> Result<Self, Error> {
+        let snap = Snapshot::build(&namespaces, &parser)?;
+        Ok(Evaluator::new(namespaces, parser, snap))
     }
 
     pub fn replace_snapshot(&mut self) {
-        let snap = Snapshot::build(&self.namespaces, &self.parser);
-        self.replace_store(snap);
+        match Snapshot::build(&self.namespaces, &self.parser) {
+            Ok(s) => {
+                self.replace_store(s);
+            }
+            Err(_) => {
+                // TODO: log::error!("error building snapshot: {}", e);
+                return;
+            }
+        };
     }
 }
 

--- a/flipt-engine/lib/evaluation/src/lib.rs
+++ b/flipt-engine/lib/evaluation/src/lib.rs
@@ -126,7 +126,6 @@ where
             }
             Err(_) => {
                 // TODO: log::error!("error building snapshot: {}", e);
-                return;
             }
         };
     }

--- a/flipt-engine/lib/evaluation/src/store/mod.rs
+++ b/flipt-engine/lib/evaluation/src/store/mod.rs
@@ -1,6 +1,6 @@
+use crate::error::Error;
 use crate::models::common;
 use crate::models::flipt;
-use crate::models::source::Document;
 use crate::parser::Parser;
 
 #[cfg(test)]
@@ -40,14 +40,14 @@ struct Namespace {
 }
 
 impl Snapshot {
-    pub fn build<P>(namespaces: &Vec<String>, parser: &P) -> Snapshot
+    pub fn build<P>(namespaces: &Vec<String>, parser: &P) -> Result<Snapshot, Error>
     where
         P: Parser + Send,
     {
         let mut ns: HashMap<String, Namespace> = HashMap::new();
 
         for n in namespaces {
-            let doc = parser.parse(n).unwrap_or(Document::default());
+            let doc = parser.parse(n)?;
 
             let mut flags: HashMap<String, flipt::Flag> = HashMap::new();
             let mut eval_rules: HashMap<String, Vec<flipt::EvaluationRule>> = HashMap::new();
@@ -207,7 +207,7 @@ impl Snapshot {
             );
         }
 
-        Self { namespaces: ns }
+        Ok(Self { namespaces: ns })
     }
 }
 
@@ -268,7 +268,7 @@ mod tests {
     fn test_snapshot() {
         let tp = TestParser::new();
 
-        let snapshot = Snapshot::build(&vec!["default".into()], &tp);
+        let snapshot = Snapshot::build(&vec!["default".into()], &tp).unwrap();
 
         let flag_variant = snapshot
             .get_flag("default", "flag1")

--- a/flipt-engine/src/lib.rs
+++ b/flipt-engine/src/lib.rs
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn initialize_engine(
     let auth_token = engine_opts.auth_token.to_owned();
 
     let parser = HTTPParser::new(&http_url, auth_token.clone().as_deref());
-    let evaluator = Evaluator::new_snapshot_evaluator(namespaces_vec, parser);
+    let evaluator = Evaluator::new_snapshot_evaluator(namespaces_vec, parser).unwrap();
 
     Box::into_raw(Box::new(Engine::new(evaluator, engine_opts))) as *mut c_void
 }


### PR DESCRIPTION
Fixes: #95 

- Modifies the `Snapshot::build` to propagate any errors instead of returning an empty Document

We still swallow the error in `replace_snapshot`, and will need to figure out what we want to do here, likely something related to #60 

This also returns an error on first call to `new_snapshot_evaluator` at engine initialization if it can't do the first call to get the snapshot from the API, which I think is likely the behavior we want for now
