### PR TITLE
chore: use strict compilerOptions for flipt-node

### DIFF
--- a/flipt-client-node/README.md
+++ b/flipt-client-node/README.md
@@ -29,7 +29,9 @@ import { FliptEvaluationClient } from '@flipt-io/flipt-client';
 // to wait for updated flag state, and the auth token if your Flipt instance requires it.
 const fliptEvaluationClient = new FliptEvaluationClient();
 
-const variant = fliptEvaluationClient.evaluateVariant("flag1", "someentity", {"fizz": "buzz"});
+const variant = fliptEvaluationClient.evaluateVariant('flag1', 'someentity', {
+  fizz: 'buzz'
+});
 
 console.log(variant);
 ```

--- a/flipt-client-node/package-lock.json
+++ b/flipt-client-node/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "flipt-client",
+  "name": "@flipt-io/flipt-client",
   "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "flipt-client",
+      "name": "@flipt-io/flipt-client",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
@@ -13,8 +13,10 @@
         "ref-napi": "^3.0.3"
       },
       "devDependencies": {
+        "@types/ffi-napi": "^4.0.10",
         "@types/jest": "^29.5.10",
         "@types/node": "^20.9.3",
+        "@types/ref-napi": "^3.0.12",
         "jest": "^29.7.0",
         "prettier": "^3.1.0",
         "ts-jest": "^29.1.1"
@@ -1071,6 +1073,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/ffi-napi": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/ffi-napi/-/ffi-napi-4.0.10.tgz",
+      "integrity": "sha512-Q6TimLDxdg+Obp4W9tgzIhSA25THD6AmR8eM+ZB7bbU96xnkpd7PRXwG4az2rKpreuF90IPr/LlQtetmIfQL2g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ref-napi": "*",
+        "@types/ref-struct-di": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1121,6 +1134,24 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ref-napi": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/ref-napi/-/ref-napi-3.0.12.tgz",
+      "integrity": "sha512-UZPKghRaLlWx2lPAphpdtYe62TbGBaPeqUM6gF1vI6FPRIu/Tff/WMAzpJRFU3jJIiD8HiXpVt2RjcFHtA6YRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ref-struct-di": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/ref-struct-di/-/ref-struct-di-1.1.12.tgz",
+      "integrity": "sha512-R2RNkGIROGoJTbXYTXrsXybnsQD4iAy26ih/G6HCeCB9luWFQKkr537XGz0uGJ1kH8y8RMkdbQmD/wBulrOPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/ref-napi": "*"
       }
     },
     "node_modules/@types/stack-utils": {

--- a/flipt-client-node/package-lock.json
+++ b/flipt-client-node/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
+        "@types/ffi": "^0.2.7",
         "ffi-napi": "^4.0.3",
         "ref-napi": "^3.0.3"
       },
@@ -1073,6 +1074,16 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/ffi": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@types/ffi/-/ffi-0.2.7.tgz",
+      "integrity": "sha512-sKgDofQcy0mvdR/vA6azFLQHoF0AKbKUGEaWeMwxZ6WCQZ/6ZUU6nIP/Zk7bstZpBsJMFvrXDUDKf/P4tB1LnQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ref": "*",
+        "@types/ref-struct": "*"
+      }
+    },
     "node_modules/@types/ffi-napi": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/@types/ffi-napi/-/ffi-napi-4.0.10.tgz",
@@ -1131,9 +1142,16 @@
       "version": "20.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.3.tgz",
       "integrity": "sha512-nk5wXLAXGBKfrhLB0cyHGbSqopS+nz0BUgZkUQqSHSSgdee0kssp1IAqlQOu333bW+gMNs2QREx7iynm19Abxw==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ref": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/ref/-/ref-0.0.32.tgz",
+      "integrity": "sha512-5q2nxslQF7GnoVzCYPsHD1B8pU020l6zy2rNw5Dzd01plmnRDj0b6thsXUOtbMjVEMAQ5uCgoajJP71f3FWiyw==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/ref-napi": {
@@ -1143,6 +1161,14 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ref-struct": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/ref-struct/-/ref-struct-0.0.33.tgz",
+      "integrity": "sha512-xLed3yIeCQaxegdXG/ZzE8PychgrfjgyWpn5TnkOqeuiIWAhMUzQPssnV8+0q1xGvbMAjd5Atfb7TWyq2oC/4Q==",
+      "dependencies": {
+        "@types/ref": "*"
       }
     },
     "node_modules/@types/ref-struct-di": {
@@ -3707,8 +3733,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",

--- a/flipt-client-node/package.json
+++ b/flipt-client-node/package.json
@@ -18,6 +18,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@types/ffi": "^0.2.7",
     "ffi-napi": "^4.0.3",
     "ref-napi": "^3.0.3"
   },

--- a/flipt-client-node/package.json
+++ b/flipt-client-node/package.json
@@ -22,8 +22,10 @@
     "ref-napi": "^3.0.3"
   },
   "devDependencies": {
+    "@types/ffi-napi": "^4.0.10",
     "@types/jest": "^29.5.10",
     "@types/node": "^20.9.3",
+    "@types/ref-napi": "^3.0.12",
     "jest": "^29.7.0",
     "prettier": "^3.1.0",
     "ts-jest": "^29.1.1"

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -53,11 +53,9 @@ export class FliptEvaluationClient {
       auth_token: ''
     }
   ) {
+    const buf = Buffer.concat([allocCString(namespace ?? 'default')]);
     const engine = engineLib.initialize_engine(
-      alloc(
-        'char *',
-        Buffer.concat([allocCString(namespace ?? 'default')]).toString()
-      ),
+      alloc('char *', buf as unknown as string),
       allocCString(JSON.stringify(engine_opts))
     );
     this.namespace = namespace ?? 'default';

--- a/flipt-client-node/tsconfig.json
+++ b/flipt-client-node/tsconfig.json
@@ -3,9 +3,10 @@
     "module": "commonjs",
     "target": "es2019",
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist/**/*"]
 }


### PR DESCRIPTION
set `strict: true` in tsc compiler options for maximum compatibility

https://dev.to/jsdev/strict-mode-typescript-j8p