### PR TITLE
feat(authentication): add support for substitutable authentication methods

### DIFF
--- a/flipt-client-go/README.md
+++ b/flipt-client-go/README.md
@@ -30,7 +30,7 @@ func main() {
   // flipt.WithNamespace(string): configures which namespace you will be making evaluations on
   // flipt.WithURL(string): configures which upstream Flipt data should be fetched from
   // flipt.WithUpdateInterval(int): configures how often data should be fetched from the upstream
-  // flipt.WithAuthToken(string): configures an auth token if your upstream Flipt instance requires it
+  // flipt.WithAuthentication(any): configures an authentication method if your upstream Flipt instance requires it
   evaluationClient, err := flipt.NewClient()
   if err != nil {
     log.Fatal(err)

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -20,7 +20,7 @@ type Client struct {
 	engine         unsafe.Pointer
 	namespace      string
 	url            string
-	authToken      string
+	authentication any
 	ref            string
 	updateInterval int
 }
@@ -35,10 +35,10 @@ func NewClient(opts ...clientOption) (*Client, error) {
 		opt(client)
 	}
 
-	engOpts := &EngineOpts{
+	engOpts := &EngineOpts[any]{
 		URL:            client.url,
 		UpdateInterval: client.updateInterval,
-		AuthToken:      client.authToken,
+		Authentication: &client.authentication,
 		Reference:      client.ref,
 	}
 
@@ -89,10 +89,10 @@ func WithUpdateInterval(updateInterval int) clientOption {
 	}
 }
 
-// WithAuthToken allows for configuring an auth token to communicate with a protected Flipt server.
-func WithAuthToken(authToken string) clientOption {
+// WithAuthentication allows for configuring an authentication method to communicate with a protected Flipt server.
+func WithAuthentication(authentication any) clientOption {
 	return func(c *Client) {
-		c.authToken = authToken
+		c.authentication = authentication
 	}
 }
 

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -26,7 +26,9 @@ func init() {
 }
 
 func TestVariant(t *testing.T) {
-	evaluationClient, err := evaluation.NewClient(evaluation.WithURL(fliptUrl), evaluation.WithAuthToken(authToken))
+	evaluationClient, err := evaluation.NewClient(evaluation.WithURL(fliptUrl), evaluation.WithAuthentication(evaluation.ClientTokenAuthentication{
+		Token: authToken,
+	}))
 	require.NoError(t, err)
 
 	variant, err := evaluationClient.EvaluateVariant(context.TODO(), "flag1", "someentity", map[string]string{
@@ -43,7 +45,9 @@ func TestVariant(t *testing.T) {
 }
 
 func TestBoolean(t *testing.T) {
-	evaluationClient, err := evaluation.NewClient(evaluation.WithURL(fliptUrl), evaluation.WithAuthToken(authToken))
+	evaluationClient, err := evaluation.NewClient(evaluation.WithURL(fliptUrl), evaluation.WithAuthentication(evaluation.ClientTokenAuthentication{
+		Token: authToken,
+	}))
 	require.NoError(t, err)
 
 	boolean, err := evaluationClient.EvaluateBoolean(context.TODO(), "flag_boolean", "someentity", map[string]string{
@@ -59,7 +63,9 @@ func TestBoolean(t *testing.T) {
 }
 
 func TestVariantFailure(t *testing.T) {
-	evaluationClient, err := evaluation.NewClient(evaluation.WithURL(fliptUrl), evaluation.WithAuthToken(authToken))
+	evaluationClient, err := evaluation.NewClient(evaluation.WithURL(fliptUrl), evaluation.WithAuthentication(evaluation.ClientTokenAuthentication{
+		Token: authToken,
+	}))
 	require.NoError(t, err)
 
 	variant, err := evaluationClient.EvaluateVariant(context.TODO(), "nonexistent", "someentity", map[string]string{
@@ -73,7 +79,9 @@ func TestVariantFailure(t *testing.T) {
 }
 
 func TestBooleanFailure(t *testing.T) {
-	evaluationClient, err := evaluation.NewClient(evaluation.WithURL(fliptUrl), evaluation.WithAuthToken(authToken))
+	evaluationClient, err := evaluation.NewClient(evaluation.WithURL(fliptUrl), evaluation.WithAuthentication(evaluation.ClientTokenAuthentication{
+		Token: authToken,
+	}))
 	require.NoError(t, err)
 
 	boolean, err := evaluationClient.EvaluateBoolean(context.TODO(), "nonexistent", "someentity", map[string]string{

--- a/flipt-client-go/models.go
+++ b/flipt-client-go/models.go
@@ -7,9 +7,17 @@ type evaluationRequest struct {
 	Context      map[string]string `json:"context"`
 }
 
-type EngineOpts struct {
+type ClientTokenAuthentication struct {
+	Token string `json:"client_token"`
+}
+
+type JWTAuthentication struct {
+	Token string `json:"jwt_token"`
+}
+
+type EngineOpts[T any] struct {
 	URL            string `json:"url,omitempty"`
-	AuthToken      string `json:"auth_token,omitempty"`
+	Authentication *T     `json:"authentication,omitempty"`
 	UpdateInterval int    `json:"update_interval,omitempty"`
 	Reference      string `json:"reference,omitempty"`
 }

--- a/flipt-client-node/README.md
+++ b/flipt-client-node/README.md
@@ -22,7 +22,9 @@ import { FliptEvaluationClient } from '@flipt-io/flipt-client';
 // {
 //  "url": "http://localhost:8080",
 //  "update_interval": 120,
-//  "auth_token": "secret"
+//  "authentication": {
+//    "client_token": "secret"
+//  }
 // }
 //
 // You can replace the url with where your upstream Flipt instance points to, the update interval for how long you are willing

--- a/flipt-client-node/src/evaluation.test.ts
+++ b/flipt-client-node/src/evaluation.test.ts
@@ -1,4 +1,5 @@
 import { FliptEvaluationClient } from '.';
+import { ClientTokenAuthentication } from './models';
 
 const fliptUrl = process.env['FLIPT_URL'];
 if (!fliptUrl) {
@@ -15,7 +16,9 @@ if (!authToken) {
 test('variant', () => {
   const client = new FliptEvaluationClient('default', {
     url: fliptUrl,
-    auth_token: authToken
+    authentication: {
+      client_token: authToken
+    }
   });
 
   try {
@@ -39,7 +42,9 @@ test('variant', () => {
 test('boolean', () => {
   const client = new FliptEvaluationClient('default', {
     url: fliptUrl,
-    auth_token: authToken
+    authentication: {
+      client_token: authToken
+    }
   });
 
   try {
@@ -61,7 +66,9 @@ test('boolean', () => {
 test('variant failure', () => {
   const client = new FliptEvaluationClient('default', {
     url: fliptUrl,
-    auth_token: authToken
+    authentication: {
+      client_token: authToken
+    }
   });
 
   try {
@@ -82,7 +89,9 @@ test('variant failure', () => {
 test('boolean failure', () => {
   const client = new FliptEvaluationClient('default', {
     url: fliptUrl,
-    auth_token: authToken
+    authentication: {
+      client_token: authToken
+    }
   });
 
   try {

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -2,6 +2,7 @@ import * as ffi from 'ffi-napi';
 import { Pointer, alloc, allocCString } from 'ref-napi';
 import * as os from 'os';
 import {
+  AuthenticationStrategy,
   BooleanResult,
   EngineOpts,
   EvaluationRequest,
@@ -47,10 +48,9 @@ export class FliptEvaluationClient {
 
   public constructor(
     namespace?: string,
-    engine_opts: EngineOpts = {
+    engine_opts: EngineOpts<AuthenticationStrategy> = {
       url: 'http://localhost:8080',
       update_interval: 120,
-      auth_token: '',
       reference: ''
     }
   ) {

--- a/flipt-client-node/src/models.ts
+++ b/flipt-client-node/src/models.ts
@@ -5,10 +5,20 @@ interface EvaluationRequest {
   context: object;
 }
 
-interface EngineOpts {
+interface AuthenticationStrategy {}
+
+interface ClientTokenAuthentication extends AuthenticationStrategy {
+  client_token: string;
+}
+
+interface JWTAuthentication extends AuthenticationStrategy {
+  jwt_token: string;
+}
+
+interface EngineOpts<T> {
   url?: string;
   update_interval?: number;
-  auth_token?: string;
+  authentication?: T;
   reference?: string;
 }
 
@@ -43,4 +53,12 @@ interface BooleanResult {
   error_message: string;
 }
 
-export { BooleanResult, EngineOpts, EvaluationRequest, VariantResult };
+export {
+  AuthenticationStrategy,
+  BooleanResult,
+  ClientTokenAuthentication,
+  EngineOpts,
+  EvaluationRequest,
+  JWTAuthentication,
+  VariantResult
+};

--- a/flipt-client-python/README.md
+++ b/flipt-client-python/README.md
@@ -19,7 +19,7 @@ from flipt_client import FliptEvaluationClient
 
 # "namespace" and "engine_opts" are two keyword arguments that this constructor accepts
 # namespace: which namespace to fetch flag state from
-# engine_opts: follows the model EngineOpts in the models.py file. Configures the url of the upstream Flipt instance, the interval in which to fetch new flag state, and the auth token if your upstream Flipt instance requires it
+# engine_opts: follows the model EngineOpts in the models.py file. Configures the url of the upstream Flipt instance, the interval in which to fetch new flag state, and the authentication method if your upstream Flipt instance requires it
 flipt_evaluation_client = FliptEvaluationClient()
 
 variant_result = flipt_evaluation_client.evaluate_variant(flag_key="flag1", entity_id="entity", context={"fizz": "buzz"})

--- a/flipt-client-python/flipt_client/__init__.py
+++ b/flipt-client-python/flipt_client/__init__.py
@@ -64,7 +64,9 @@ class FliptEvaluationClient:
         ns = (ctypes.c_char_p * len(namespace_list))()
         ns[:] = [s.encode("utf-8") for s in namespace_list]
 
-        engine_opts_serialized = engine_opts.model_dump_json().encode("utf-8")
+        engine_opts_serialized = engine_opts.model_dump_json(exclude_none=True).encode(
+            "utf-8"
+        )
 
         self.engine = self.ffi_core.initialize_engine(ns, engine_opts_serialized)
 

--- a/flipt-client-python/flipt_client/models.py
+++ b/flipt-client-python/flipt_client/models.py
@@ -9,10 +9,23 @@ class EvaluationRequest(BaseModel):
     context: dict
 
 
+class AuthenticationStrategy(BaseModel):
+    client_token: Optional[str] = None
+    jwt_token: Optional[str] = None
+
+
+class ClientTokenAuthentication(AuthenticationStrategy):
+    client_token: str
+
+
+class JWTAuthentication(AuthenticationStrategy):
+    jwt_token: str
+
+
 class EngineOpts(BaseModel):
     url: Optional[str] = None
     update_interval: Optional[int] = None
-    auth_token: Optional[str] = None
+    authentication: Optional[AuthenticationStrategy] = None
     reference: Optional[str] = None
 
 

--- a/flipt-client-python/tests/__init__.py
+++ b/flipt-client-python/tests/__init__.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from flipt_client import FliptEvaluationClient
-from flipt_client.models import EngineOpts
+from flipt_client.models import ClientTokenAuthentication, EngineOpts
 
 
 class TestFliptEvaluationClient(unittest.TestCase):
@@ -15,7 +15,10 @@ class TestFliptEvaluationClient(unittest.TestCase):
             raise Exception("FLIPT_AUTH_TOKEN not set")
 
         self.flipt_client = FliptEvaluationClient(
-            engine_opts=EngineOpts(url=engine_url, auth_token=auth_token)
+            engine_opts=EngineOpts(
+                url=engine_url,
+                authentication=ClientTokenAuthentication(client_token=auth_token),
+            )
         )
 
     def test_variant(self):

--- a/flipt-client-ruby/README.md
+++ b/flipt-client-ruby/README.md
@@ -33,7 +33,9 @@ require 'flipt_client'
 # {
 #   "url": "http://localhost:8080",
 #   "update_interval": 120,
-#   "auth_token": "secret"
+#   "authentication": {
+#     "client_token": "secret" 
+#   }
 # }
 # 
 # You can replace the url with where your upstream Flipt instance points to, the update interval for how long you are willing

--- a/flipt-client-ruby/spec/evaluation_spec.rb
+++ b/flipt-client-ruby/spec/evaluation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipt::EvaluationClient do
   before(:all) do
     url = ENV.fetch('FLIPT_URL', 'http://localhost:8080')
     auth_token = ENV.fetch('FLIPT_AUTH_TOKEN', 'secret')
-    @client = Flipt::EvaluationClient.new('default', { url: url, auth_token: auth_token })
+    @client = Flipt::EvaluationClient.new('default', { url: url, authentication: { client_token: auth_token } })
   end
 
   describe '#evaluate_variant' do

--- a/flipt-engine-ffi/examples/evaluation.rs
+++ b/flipt-engine-ffi/examples/evaluation.rs
@@ -9,7 +9,7 @@ fn main() {
     let evaluator = Evaluator::new_snapshot_evaluator(
         vec!["default".into()],
         HTTPParserBuilder::new("http://localhost:8080")
-            .authentication(&Authentication::with_client_token("secret".into()))
+            .authentication(Authentication::with_client_token("secret".into()))
             .build(),
     )
     .unwrap();

--- a/flipt-engine-ffi/examples/evaluation.rs
+++ b/flipt-engine-ffi/examples/evaluation.rs
@@ -1,7 +1,7 @@
 // cargo run --example evaluation
 
 use fliptengine::{self};
-use fliptevaluation::parser::HTTPParserBuilder;
+use fliptevaluation::parser::{Authentication, HTTPParserBuilder};
 use fliptevaluation::{EvaluationRequest, Evaluator};
 use std::collections::HashMap;
 
@@ -9,7 +9,7 @@ fn main() {
     let evaluator = Evaluator::new_snapshot_evaluator(
         vec!["default".into()],
         HTTPParserBuilder::new("http://localhost:8080")
-            .auth_token("secret")
+            .authentication(&Authentication::with_client_token("secret".into()))
             .build(),
     )
     .unwrap();

--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn initialize_engine(
     let mut parser_builder = HTTPParserBuilder::new(&http_url);
 
     parser_builder = match authentication {
-        Some(authentication) => parser_builder.authentication(&authentication),
+        Some(authentication) => parser_builder.authentication(authentication),
         None => parser_builder,
     };
 

--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -1,5 +1,5 @@
 use fliptevaluation::error::Error;
-use fliptevaluation::parser::{HTTPParser, HTTPParserBuilder};
+use fliptevaluation::parser::{Authentication, HTTPParser, HTTPParserBuilder};
 use fliptevaluation::store::Snapshot;
 use fliptevaluation::{
     BooleanEvaluationResponse, EvaluationRequest, Evaluator, VariantEvaluationResponse,
@@ -67,7 +67,7 @@ fn result_to_json_ptr<T: Serialize>(result: Result<T, Error>) -> *mut c_char {
 #[derive(Deserialize)]
 pub struct EngineOpts {
     url: Option<String>,
-    auth_token: Option<String>,
+    authentication: Option<Authentication>,
     update_interval: Option<u64>,
     reference: Option<String>,
 }
@@ -76,7 +76,7 @@ impl Default for EngineOpts {
     fn default() -> Self {
         Self {
             url: Some("http://localhost:8080".into()),
-            auth_token: None,
+            authentication: None,
             update_interval: Some(120),
             reference: None,
         }
@@ -181,13 +181,13 @@ pub unsafe extern "C" fn initialize_engine(
         .to_owned()
         .unwrap_or("http://localhost:8080".into());
 
-    let auth_token = engine_opts.auth_token.to_owned();
+    let authentication = engine_opts.authentication.to_owned();
     let reference = engine_opts.reference.to_owned();
 
     let mut parser_builder = HTTPParserBuilder::new(&http_url);
 
-    parser_builder = match auth_token {
-        Some(token) => parser_builder.auth_token(&token),
+    parser_builder = match authentication {
+        Some(authentication) => parser_builder.authentication(&authentication),
         None => parser_builder,
     };
 

--- a/flipt-evaluation/src/parser/mod.rs
+++ b/flipt-evaluation/src/parser/mod.rs
@@ -8,37 +8,36 @@ pub trait Parser {
     fn parse(&self, namespace: &str) -> Result<source::Document, Error>;
 }
 
-#[derive(Deserialize, Clone)]
-pub struct Authentication {
-    client_token: Option<String>,
-    jwt_token: Option<String>,
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Authentication {
+    #[default]
+    None,
+    ClientToken(String),
+    JWTToken(String),
 }
 
 impl Authentication {
     pub fn with_client_token(token: String) -> Self {
-        Self {
-            client_token: Some(token),
-            jwt_token: None,
-        }
+        Authentication::ClientToken(token)
     }
 
     pub fn with_jwt_token(token: String) -> Self {
-        Self {
-            client_token: None,
-            jwt_token: Some(token),
-        }
+        Authentication::JWTToken(token)
     }
 
     pub fn authenticate(&self) -> Option<String> {
-        if let Some(token) = &self.client_token {
-            let header_format: String = format!("Bearer {}", token).parse().unwrap();
-            return Some(header_format);
-        } else if let Some(token) = &self.jwt_token {
-            let header_format: String = format!("JWT {}", token).parse().unwrap();
-            return Some(header_format);
+        match self {
+            Authentication::ClientToken(token) => {
+                let header_format: String = format!("Bearer {}", token).parse().unwrap();
+                Some(header_format)
+            }
+            Authentication::JWTToken(token) => {
+                let header_format: String = format!("JWT {}", token).parse().unwrap();
+                Some(header_format)
+            }
+            Authentication::None => None,
         }
-
-        None
     }
 }
 


### PR DESCRIPTION
This PR adds support for substitutable authentication methods. The purpose of this is for the client to either provide a Bearer or JWT token.

Completes FLI-763