### PR TITLE
feat(client-sdks): add batch evaluation to engine

### DIFF
--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -160,7 +160,7 @@ func (e *Client) EvaluateBoolean(_ context.Context, flagKey, entityID string, ev
 }
 
 // EvaluateBatch makes an evaluation on a batch of flags.
-func (e *Client) EvaluateBatch(_ context.Context, inputEvaluationRequests []*InputEvaluationRequest) (*BatchResult, error) {
+func (e *Client) EvaluateBatch(_ context.Context, inputEvaluationRequests []*EvaluationRequest) (*BatchResult, error) {
 	evaluationRequests := make([]*evaluationRequest, 0, len(inputEvaluationRequests))
 
 	for _, ir := range inputEvaluationRequests {

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -160,10 +160,10 @@ func (e *Client) EvaluateBoolean(_ context.Context, flagKey, entityID string, ev
 }
 
 // EvaluateBatch makes an evaluation on a batch of flags.
-func (e *Client) EvaluateBatch(_ context.Context, inputEvaluationRequests []*EvaluationRequest) (*BatchResult, error) {
-	evaluationRequests := make([]*evaluationRequest, 0, len(inputEvaluationRequests))
+func (e *Client) EvaluateBatch(_ context.Context, requests []*EvaluationRequest) (*BatchResult, error) {
+	evaluationRequests := make([]*evaluationRequest, 0, len(requests))
 
-	for _, ir := range inputEvaluationRequests {
+	for _, ir := range requests {
 		evaluationRequests = append(evaluationRequests, &evaluationRequest{
 			NamespaceKey: e.namespace,
 			FlagKey:      ir.FlagKey,

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -64,7 +64,7 @@ func TestBatch(t *testing.T) {
 	evaluationClient, err := flipt.NewClient(flipt.WithURL(fliptUrl), flipt.WithClientTokenAuthentication(authToken))
 	require.NoError(t, err)
 
-	batch, err := evaluationClient.EvaluateBatch(context.TODO(), []*flipt.InputEvaluationRequest{
+	batch, err := evaluationClient.EvaluateBatch(context.TODO(), []*flipt.EvaluationRequest{
 		{
 			FlagKey:  "flag1",
 			EntityId: "someentity",

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -60,6 +60,60 @@ func TestBoolean(t *testing.T) {
 	assert.Equal(t, "MATCH_EVALUATION_REASON", boolean.Result.Reason)
 }
 
+func TestBatch(t *testing.T) {
+	evaluationClient, err := flipt.NewClient(flipt.WithURL(fliptUrl), flipt.WithClientTokenAuthentication(authToken))
+	require.NoError(t, err)
+
+	batch, err := evaluationClient.EvaluateBatch(context.TODO(), []*flipt.InputEvaluationRequest{
+		{
+			FlagKey:  "flag1",
+			EntityId: "someentity",
+			Context: map[string]string{
+				"fizz": "buzz",
+			},
+		},
+		{
+			FlagKey:  "flag_boolean",
+			EntityId: "someentity",
+			Context: map[string]string{
+				"fizz": "buzz",
+			},
+		},
+		{
+			FlagKey:  "notfound",
+			EntityId: "someentity",
+			Context: map[string]string{
+				"fizz": "buzz",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "success", batch.Status)
+	assert.Empty(t, batch.ErrorMessage)
+
+	assert.Len(t, batch.Result.Responses, 3)
+
+	variant := batch.Result.Responses[0]
+	assert.Equal(t, "VARIANT_EVALUATION_RESPONSE_TYPE", variant.Type)
+	assert.True(t, variant.VariantEvaluationResponse.Match)
+	assert.Equal(t, "flag1", variant.VariantEvaluationResponse.FlagKey)
+	assert.Equal(t, "MATCH_EVALUATION_REASON", variant.VariantEvaluationResponse.Reason)
+	assert.Contains(t, variant.VariantEvaluationResponse.SegmentKeys, "segment1")
+
+	boolean := batch.Result.Responses[1]
+	assert.Equal(t, "BOOLEAN_EVALUATION_RESPONSE_TYPE", boolean.Type)
+	assert.Equal(t, "flag_boolean", boolean.BooleanEvaluationResponse.FlagKey)
+	assert.True(t, boolean.BooleanEvaluationResponse.Enabled)
+	assert.Equal(t, "MATCH_EVALUATION_REASON", boolean.BooleanEvaluationResponse.Reason)
+
+	errorResponse := batch.Result.Responses[2]
+	assert.Equal(t, "ERROR_EVALUATION_RESPONSE_TYPE", errorResponse.Type)
+	assert.Equal(t, "notfound", errorResponse.ErrorEvaluationResponse.FlagKey)
+	assert.Equal(t, "default", errorResponse.ErrorEvaluationResponse.NamespaceKey)
+	assert.Equal(t, "NOT_FOUND_ERROR_EVALUATION_REASON", errorResponse.ErrorEvaluationResponse.Reason)
+}
+
 func TestVariantFailure(t *testing.T) {
 	evaluationClient, err := flipt.NewClient(flipt.WithURL(fliptUrl), flipt.WithClientTokenAuthentication(authToken))
 	require.NoError(t, err)

--- a/flipt-client-go/models.go
+++ b/flipt-client-go/models.go
@@ -7,6 +7,12 @@ type evaluationRequest struct {
 	Context      map[string]string `json:"context"`
 }
 
+type InputEvaluationRequest struct {
+	FlagKey  string            `json:"flag_key"`
+	EntityId string            `json:"entity_id"`
+	Context  map[string]string `json:"context"`
+}
+
 type clientTokenAuthentication struct {
 	Token string `json:"client_token"`
 }
@@ -41,6 +47,24 @@ type BooleanEvaluationResponse struct {
 	Timestamp             string  `json:"timestamp"`
 }
 
+type ErrorEvaluationResponse struct {
+	FlagKey      string `json:"flag_key"`
+	NamespaceKey string `json:"namespace_key"`
+	Reason       string `json:"reason"`
+}
+
+type BatchEvaluationResponse struct {
+	Responses             []*Response `json:"responses"`
+	RequestDurationMillis float64     `json:"request_duration_millis"`
+}
+
+type Response struct {
+	Type                      string                     `json:"type"`
+	VariantEvaluationResponse *VariantEvaluationResponse `json:"variant_evaluation_response,omitempty"`
+	BooleanEvaluationResponse *BooleanEvaluationResponse `json:"boolean_evaluation_response,omitempty"`
+	ErrorEvaluationResponse   *ErrorEvaluationResponse   `json:"error_evaluation_response,omitempty"`
+}
+
 type Result[R any] struct {
 	Status       string `json:"status"`
 	Result       *R     `json:"result,omitempty"`
@@ -50,3 +74,5 @@ type Result[R any] struct {
 type VariantResult Result[VariantEvaluationResponse]
 
 type BooleanResult Result[BooleanEvaluationResponse]
+
+type BatchResult Result[BatchEvaluationResponse]

--- a/flipt-client-go/models.go
+++ b/flipt-client-go/models.go
@@ -7,7 +7,7 @@ type evaluationRequest struct {
 	Context      map[string]string `json:"context"`
 }
 
-type InputEvaluationRequest struct {
+type EvaluationRequest struct {
 	FlagKey  string            `json:"flag_key"`
 	EntityId string            `json:"entity_id"`
 	Context  map[string]string `json:"context"`

--- a/flipt-client-node/src/evaluation.test.ts
+++ b/flipt-client-node/src/evaluation.test.ts
@@ -63,6 +63,80 @@ test('boolean', () => {
   }
 });
 
+test('batch', () => {
+  const client = new FliptEvaluationClient('default', {
+    url: fliptUrl,
+    authentication: {
+      client_token: authToken
+    }
+  });
+
+  try {
+    const batch = client.evaluateBatch([
+      {
+        flag_key: 'flag1',
+        entity_id: 'someentity',
+        context: {
+          fizz: 'buzz'
+        }
+      },
+      {
+        flag_key: 'flag_boolean',
+        entity_id: 'someentity',
+        context: {
+          fizz: 'buzz'
+        }
+      },
+      {
+        flag_key: 'notfound',
+        entity_id: 'someentity',
+        context: {
+          fizz: 'buzz'
+        }
+      }
+    ]);
+
+    expect(batch.error_message).toBeNull();
+    expect(batch.status).toEqual('success');
+    expect(batch.result).toBeDefined();
+
+    expect(batch.result?.responses).toHaveLength(3);
+    const variant = batch.result?.responses[0];
+    expect(variant?.type).toEqual('VARIANT_EVALUATION_RESPONSE_TYPE');
+    expect(variant?.variant_evaluation_response?.flag_key).toEqual('flag1');
+    expect(variant?.variant_evaluation_response?.match).toEqual(true);
+    expect(variant?.variant_evaluation_response?.reason).toEqual(
+      'MATCH_EVALUATION_REASON'
+    );
+    expect(variant?.variant_evaluation_response?.segment_keys).toContain(
+      'segment1'
+    );
+    expect(variant?.variant_evaluation_response?.variant_key).toContain(
+      'variant1'
+    );
+
+    const boolean = batch.result?.responses[1];
+    expect(boolean?.type).toEqual('BOOLEAN_EVALUATION_RESPONSE_TYPE');
+    expect(boolean?.boolean_evaluation_response?.flag_key).toEqual(
+      'flag_boolean'
+    );
+    expect(boolean?.boolean_evaluation_response?.enabled).toEqual(true);
+    expect(boolean?.boolean_evaluation_response?.reason).toEqual(
+      'MATCH_EVALUATION_REASON'
+    );
+
+    const error = batch.result?.responses[2];
+    expect(error?.type).toEqual('ERROR_EVALUATION_RESPONSE_TYPE');
+    expect(error?.error_evaluation_response?.flag_key).toEqual('notfound');
+    expect(error?.error_evaluation_response?.namespace_key).toEqual('default');
+    expect(error?.error_evaluation_response?.reason).toEqual(
+      'NOT_FOUND_ERROR_EVALUATION_REASON'
+    );
+  } finally {
+    if (client) client.close();
+  }
+});
+
 test('variant failure', () => {
   const client = new FliptEvaluationClient('default', {
     url: fliptUrl,

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -7,12 +7,18 @@ import {
   BatchResult,
   EngineOpts,
   EvaluationRequest,
-  InputEvaluationRequest,
   VariantResult
 } from './models';
 import * as path from 'path';
 
 let libfile = '';
+
+interface EvalRequest {
+  namespace_key: string;
+  flag_key: string;
+  entity_id: string;
+  context: object;
+}
 
 // get absolute path to libfliptengine
 switch (os.platform()) {
@@ -71,7 +77,7 @@ export class FliptEvaluationClient {
     entity_id: string,
     context: {}
   ): VariantResult {
-    const evaluation_request: EvaluationRequest = {
+    const evaluation_request: EvalRequest = {
       namespace_key: this.namespace,
       flag_key: flag_key,
       entity_id: entity_id,
@@ -95,7 +101,7 @@ export class FliptEvaluationClient {
     entity_id: string,
     context: {}
   ): BooleanResult {
-    const evaluation_request: EvaluationRequest = {
+    const evaluation_request: EvalRequest = {
       namespace_key: this.namespace,
       flag_key: flag_key,
       entity_id: entity_id,
@@ -114,8 +120,8 @@ export class FliptEvaluationClient {
     return JSON.parse(Buffer.from(response).toString('utf-8'));
   }
 
-  public evaluateBatch(requests: InputEvaluationRequest[]): BatchResult {
-    const evaluationRequests: EvaluationRequest[] = [];
+  public evaluateBatch(requests: EvaluationRequest[]): BatchResult {
+    const evaluationRequests: EvalRequest[] = [];
     for (const request of requests) {
       evaluationRequests.push({
         namespace_key: this.namespace,

--- a/flipt-client-node/src/models.ts
+++ b/flipt-client-node/src/models.ts
@@ -22,6 +22,12 @@ interface EngineOpts<T> {
   reference?: string;
 }
 
+interface InputEvaluationRequest {
+  flag_key: string;
+  entity_id: string;
+  context: object;
+}
+
 interface VariantEvaluationResponse {
   match: boolean;
   segment_keys: string[];
@@ -41,6 +47,24 @@ interface BooleanEvaluationResponse {
   timestamp: string;
 }
 
+interface ErrorEvaluationResponse {
+  flag_key: string;
+  namespace_key: string;
+  reason: string;
+}
+
+interface EvaluationResponse {
+  type: string;
+  boolean_evaluation_response?: BooleanEvaluationResponse;
+  variant_evaluation_response?: VariantEvaluationResponse;
+  error_evaluation_response?: ErrorEvaluationResponse;
+}
+
+interface BatchEvaluationResponse {
+  responses: EvaluationResponse[];
+  request_duration_millis: number;
+}
+
 interface VariantResult {
   status: string;
   result: VariantEvaluationResponse;
@@ -53,12 +77,20 @@ interface BooleanResult {
   error_message: string;
 }
 
+interface BatchResult {
+  status: string;
+  result?: BatchEvaluationResponse;
+  error_message: string;
+}
+
 export {
   AuthenticationStrategy,
   BooleanResult,
+  BatchResult,
   ClientTokenAuthentication,
   EngineOpts,
   EvaluationRequest,
+  InputEvaluationRequest,
   JWTAuthentication,
   VariantResult
 };

--- a/flipt-client-node/src/models.ts
+++ b/flipt-client-node/src/models.ts
@@ -1,10 +1,3 @@
-interface EvaluationRequest {
-  namespace_key: string;
-  flag_key: string;
-  entity_id: string;
-  context: object;
-}
-
 interface AuthenticationStrategy {}
 
 interface ClientTokenAuthentication extends AuthenticationStrategy {
@@ -22,7 +15,7 @@ interface EngineOpts<T> {
   reference?: string;
 }
 
-interface InputEvaluationRequest {
+interface EvaluationRequest {
   flag_key: string;
   entity_id: string;
   context: object;
@@ -90,7 +83,6 @@ export {
   ClientTokenAuthentication,
   EngineOpts,
   EvaluationRequest,
-  InputEvaluationRequest,
   JWTAuthentication,
   VariantResult
 };

--- a/flipt-client-python/flipt_client/__init__.py
+++ b/flipt-client-python/flipt_client/__init__.py
@@ -1,3 +1,4 @@
+from pydantic import BaseModel
 import ctypes
 import os
 import platform
@@ -5,13 +6,19 @@ import platform
 from .models import (
     BatchResult,
     BooleanResult,
-    InputEvaluationRequest,
     EngineOpts,
     EvaluationRequest,
     VariantResult,
 )
 
 from typing import List
+
+
+class EvalRequest(BaseModel):
+    namespace_key: str
+    flag_key: str
+    entity_id: str
+    context: dict
 
 
 class FliptEvaluationClient:
@@ -113,12 +120,12 @@ class FliptEvaluationClient:
 
         return boolean_result
 
-    def evaluate_batch(self, requests: List[InputEvaluationRequest]) -> BatchResult:
+    def evaluate_batch(self, requests: List[EvaluationRequest]) -> BatchResult:
         evaluation_requests = []
 
         for r in requests:
             evaluation_requests.append(
-                EvaluationRequest(
+                EvalRequest(
                     namespace_key=self.namespace_key,
                     flag_key=r.flag_key,
                     entity_id=r.entity_id,
@@ -146,7 +153,7 @@ class FliptEvaluationClient:
 def serialize_evaluation_request(
     namespace_key: str, flag_key: str, entity_id: str, context: dict
 ) -> str:
-    evaluation_request = EvaluationRequest(
+    evaluation_request = EvalRequest(
         namespace_key=namespace_key,
         flag_key=flag_key,
         entity_id=entity_id,

--- a/flipt-client-python/flipt_client/models.py
+++ b/flipt-client-python/flipt_client/models.py
@@ -3,13 +3,6 @@ from typing import List, Optional
 
 
 class EvaluationRequest(BaseModel):
-    namespace_key: str
-    flag_key: str
-    entity_id: str
-    context: dict
-
-
-class InputEvaluationRequest(BaseModel):
     flag_key: str
     entity_id: str
     context: dict

--- a/flipt-client-python/flipt_client/models.py
+++ b/flipt-client-python/flipt_client/models.py
@@ -9,6 +9,12 @@ class EvaluationRequest(BaseModel):
     context: dict
 
 
+class InputEvaluationRequest(BaseModel):
+    flag_key: str
+    entity_id: str
+    context: dict
+
+
 class AuthenticationStrategy(BaseModel):
     client_token: Optional[str] = None
     jwt_token: Optional[str] = None
@@ -48,6 +54,24 @@ class BooleanEvaluationResponse(BaseModel):
     timestamp: str
 
 
+class ErrorEvaluationResponse(BaseModel):
+    flag_key: str
+    namespace_key: str
+    reason: str
+
+
+class EvaluationResponse(BaseModel):
+    type: str
+    boolean_evaluation_response: Optional[BooleanEvaluationResponse] = None
+    variant_evaluation_response: Optional[VariantEvaluationResponse] = None
+    error_evaluation_response: Optional[ErrorEvaluationResponse] = None
+
+
+class BatchEvaluationResponse(BaseModel):
+    responses: List[EvaluationResponse]
+    request_duration_millis: float
+
+
 class VariantResult(BaseModel):
     status: str
     result: Optional[VariantEvaluationResponse] = None
@@ -57,4 +81,10 @@ class VariantResult(BaseModel):
 class BooleanResult(BaseModel):
     status: str
     result: Optional[BooleanEvaluationResponse] = None
+    error_message: Optional[str] = None
+
+
+class BatchResult(BaseModel):
+    status: str
+    result: Optional[BatchEvaluationResponse] = None
     error_message: Optional[str] = None

--- a/flipt-client-python/tests/__init__.py
+++ b/flipt-client-python/tests/__init__.py
@@ -4,7 +4,7 @@ from flipt_client import FliptEvaluationClient
 from flipt_client.models import (
     ClientTokenAuthentication,
     EngineOpts,
-    InputEvaluationRequest,
+    EvaluationRequest,
 )
 
 
@@ -50,17 +50,17 @@ class TestFliptEvaluationClient(unittest.TestCase):
     def test_batch(self):
         batch = self.flipt_client.evaluate_batch(
             [
-                InputEvaluationRequest(
+                EvaluationRequest(
                     flag_key="flag1",
                     entity_id="someentity",
                     context={"fizz": "buzz"},
                 ),
-                InputEvaluationRequest(
+                EvaluationRequest(
                     flag_key="flag_boolean",
                     entity_id="someentity",
                     context={"fizz": "buzz"},
                 ),
-                InputEvaluationRequest(
+                EvaluationRequest(
                     flag_key="notfound",
                     entity_id="someentity",
                     context={"fizz": "buzz"},

--- a/flipt-client-ruby/lib/flipt_client.rb
+++ b/flipt-client-ruby/lib/flipt_client.rb
@@ -36,6 +36,8 @@ module Flipt
     attach_function :evaluate_variant, %i[pointer string], :string
     # const char *evaluate_boolean(void *engine_ptr, const char *evaluation_request);
     attach_function :evaluate_boolean, %i[pointer string], :string
+    # const char *evaluate_batch(void *engine_ptr, const char *batch_evaluation_request);
+    attach_function :evaluate_batch, %i[pointer string], :string
 
     # Create a new Flipt client
     #
@@ -91,6 +93,22 @@ module Flipt
       evaluation_request[:namespace_key] = @namespace
       validate_evaluation_request(evaluation_request)
       resp = self.class.evaluate_boolean(@engine, evaluation_request.to_json)
+      JSON.parse(resp)
+    end
+  
+    # Evaluate a batch of flags for a given request
+    #
+    # @param batch_evaluation_request [Array<Hash>] batch evaluation request
+    #   - :entity_id [String] entity id
+    #   - :flag_key [String] flag key
+    #   - :namespace_key [String] override namespace key
+    def evaluate_batch(batch_evaluation_request = [])
+      for request in batch_evaluation_request do
+        request[:namespace_key] = @namespace
+        validate_evaluation_request(request)
+      end
+
+      resp = self.class.evaluate_batch(@engine, batch_evaluation_request.to_json)
       JSON.parse(resp)
     end
 

--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -2,7 +2,7 @@ use fliptevaluation::error::Error;
 use fliptevaluation::parser::{Authentication, HTTPParser, HTTPParserBuilder};
 use fliptevaluation::store::Snapshot;
 use fliptevaluation::{
-    BooleanEvaluationResponse, EvaluationRequest, Evaluator, VariantEvaluationResponse,
+    BooleanEvaluationResponse, EvaluationRequest, Evaluator, VariantEvaluationResponse, BatchEvaluationResponse,
 };
 use libc::c_void;
 use serde::{Deserialize, Serialize};
@@ -130,6 +130,16 @@ impl Engine {
 
         lock.boolean(evaluation_request)
     }
+
+    pub fn batch(
+        &self,
+        batch_evaluation_request: Vec<EvaluationRequest>,
+    ) -> Result<BatchEvaluationResponse, Error> {
+        let binding = self.evaluator.clone();
+        let lock = binding.lock().unwrap();
+
+        lock.batch(batch_evaluation_request)
+    }
 }
 
 /// # Safety
@@ -229,6 +239,48 @@ pub unsafe extern "C" fn evaluate_boolean(
     let e_req = get_evaluation_request(evaluation_request);
 
     result_to_json_ptr(e.boolean(&e_req))
+}
+
+/// # Safety
+///
+/// This function will take in a pointer to the engine and return a batch evaluation response.
+#[no_mangle]
+pub unsafe extern "C" fn evaluate_batch(
+    engine_ptr: *mut c_void,
+    batch_evaluation_request: *const c_char,
+) -> *const c_char {
+    let e = get_engine(engine_ptr).unwrap();
+    let req = get_batch_evaluation_request(batch_evaluation_request);
+
+    result_to_json_ptr(e.batch(req))
+}
+
+unsafe fn get_batch_evaluation_request(batch_evaluation_request: *const c_char) -> Vec<EvaluationRequest> {
+    let evaluation_request_bytes = CStr::from_ptr(batch_evaluation_request).to_bytes();
+    let bytes_str_repr = std::str::from_utf8(evaluation_request_bytes).unwrap();
+
+    let batch_eval_request: Vec<EvalRequest> = serde_json::from_str(bytes_str_repr).unwrap();
+
+    let mut evaluation_requests: Vec<EvaluationRequest> = Vec::with_capacity(batch_eval_request.len());
+    for req in batch_eval_request {
+        let mut context_map: HashMap<String, String> = HashMap::new();
+        if let Some(context_value) = req.context {
+            for (key, value) in context_value {
+                if let serde_json::Value::String(val) = value {
+                    context_map.insert(key, val);
+                }
+            }
+        }
+
+        evaluation_requests.push(EvaluationRequest {
+            namespace_key: req.namespace_key,
+            flag_key: req.flag_key,
+            entity_id: req.entity_id,
+            context: context_map,
+        });
+    }
+
+    evaluation_requests
 }
 
 unsafe fn get_evaluation_request(evaluation_request: *const c_char) -> EvaluationRequest {

--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -2,7 +2,8 @@ use fliptevaluation::error::Error;
 use fliptevaluation::parser::{Authentication, HTTPParser, HTTPParserBuilder};
 use fliptevaluation::store::Snapshot;
 use fliptevaluation::{
-    BooleanEvaluationResponse, EvaluationRequest, Evaluator, VariantEvaluationResponse, BatchEvaluationResponse,
+    BatchEvaluationResponse, BooleanEvaluationResponse, EvaluationRequest, Evaluator,
+    VariantEvaluationResponse,
 };
 use libc::c_void;
 use serde::{Deserialize, Serialize};
@@ -255,13 +256,16 @@ pub unsafe extern "C" fn evaluate_batch(
     result_to_json_ptr(e.batch(req))
 }
 
-unsafe fn get_batch_evaluation_request(batch_evaluation_request: *const c_char) -> Vec<EvaluationRequest> {
+unsafe fn get_batch_evaluation_request(
+    batch_evaluation_request: *const c_char,
+) -> Vec<EvaluationRequest> {
     let evaluation_request_bytes = CStr::from_ptr(batch_evaluation_request).to_bytes();
     let bytes_str_repr = std::str::from_utf8(evaluation_request_bytes).unwrap();
 
     let batch_eval_request: Vec<EvalRequest> = serde_json::from_str(bytes_str_repr).unwrap();
 
-    let mut evaluation_requests: Vec<EvaluationRequest> = Vec::with_capacity(batch_eval_request.len());
+    let mut evaluation_requests: Vec<EvaluationRequest> =
+        Vec::with_capacity(batch_eval_request.len());
     for req in batch_eval_request {
         let mut context_map: HashMap<String, String> = HashMap::new();
         if let Some(context_value) = req.context {

--- a/flipt-evaluation/src/models/common.rs
+++ b/flipt-evaluation/src/models/common.rs
@@ -66,10 +66,20 @@ pub enum EvaluationReason {
     Default,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum ErrorEvaluationReason {
     #[serde(rename = "UNKNOWN_ERROR_EVALUATION_REASON")]
     Unknown,
     #[serde(rename = "NOT_FOUND_ERROR_EVALUATION_REASON")]
     NotFound,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ResponseType {
+    #[serde(rename = "VARIANT_EVALUATION_RESPONSE_TYPE")]
+    Variant,
+    #[serde(rename = "BOOLEAN_EVALUATION_RESPONSE_TYPE")]
+    Boolean,
+    #[serde(rename = "ERROR_EVALUATION_RESPONSE_TYPE")]
+    Error,
 }


### PR DESCRIPTION
Add batch evaluation to engine + clients.

This was missing previously, so we are adding it for users to be able to leverage the batch evaluation functionality.