### PR TITLE
chore(breaking): java rename shutdown to close to be consistent

### DIFF
--- a/flipt-client-java/README.md
+++ b/flipt-client-java/README.md
@@ -53,7 +53,14 @@ public class Main {
 
             Result<VariantEvaluationResponse> result =
                     fliptClient.evaluateVariant("flag1", "entity", context);
-        } catch (Exception e) {}
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            // Important: always close the client to release resources
+            if (fliptClient != null) {
+                fliptClient.close();
+            }
+        }
     }
 }
 ```

--- a/flipt-client-java/src/main/java/io/flipt/client/FliptEvaluationClient.java
+++ b/flipt-client-java/src/main/java/io/flipt/client/FliptEvaluationClient.java
@@ -188,7 +188,7 @@ public class FliptEvaluationClient {
     return this.objectMapper.readValue(value, typeRef);
   }
 
-  public void shutdown() {
+  public void close() {
     CLibrary.INSTANCE.destroy_engine(this.engine);
   }
 }

--- a/flipt-client-java/src/test/java/TestFliptEvaluationClient.java
+++ b/flipt-client-java/src/test/java/TestFliptEvaluationClient.java
@@ -2,6 +2,7 @@ import io.flipt.client.FliptEvaluationClient;
 import io.flipt.client.models.*;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -102,5 +103,10 @@ public class TestFliptEvaluationClient {
     Assertions.assertEquals("notfound", errorResponse.getFlagKey());
     Assertions.assertEquals("default", errorResponse.getNamespaceKey());
     Assertions.assertEquals("NOT_FOUND_ERROR_EVALUATION_REASON", errorResponse.getReason());
+  }
+
+  @AfterAll
+  static void tearDownAll() throws Exception {
+    if (fliptClient != null) fliptClient.close();
   }
 }


### PR DESCRIPTION
java rename shutdown to close to be consistent with other libs; add close to Java example