### PR TITLE
fix(engine-ffi): prevent memory leaks

### DIFF
--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -116,7 +116,7 @@ func (e *Client) EvaluateVariant(_ context.Context, flagKey, entityID string, ev
 	defer C.free(unsafe.Pointer(cr))
 
 	variant := C.evaluate_variant(e.engine, cr)
-	defer C.free(unsafe.Pointer(variant))
+	defer C.destroy_string(variant)
 
 	b := C.GoBytes(unsafe.Pointer(variant), (C.int)(C.strlen(variant)))
 
@@ -145,7 +145,7 @@ func (e *Client) EvaluateBoolean(_ context.Context, flagKey, entityID string, ev
 	defer C.free(unsafe.Pointer(cr))
 
 	boolean := C.evaluate_boolean(e.engine, cr)
-	defer C.free(unsafe.Pointer(boolean))
+	defer C.destroy_string(boolean)
 
 	b := C.GoBytes(unsafe.Pointer(boolean), (C.int)(C.strlen(boolean)))
 
@@ -180,7 +180,7 @@ func (e *Client) EvaluateBatch(_ context.Context, requests []*EvaluationRequest)
 	defer C.free(unsafe.Pointer(cr))
 
 	batch := C.evaluate_batch(e.engine, cr)
-	defer C.free(unsafe.Pointer(batch))
+	defer C.destroy_string(batch)
 
 	b := C.GoBytes(unsafe.Pointer(batch), (C.int)(C.strlen(batch)))
 
@@ -195,7 +195,7 @@ func (e *Client) EvaluateBatch(_ context.Context, requests []*EvaluationRequest)
 
 func (e *Client) ListFlags(_ context.Context) (*ListFlagsResult, error) {
 	flags := C.list_flags(e.engine)
-	defer C.free(unsafe.Pointer(flags))
+	defer C.destroy_string(flags)
 
 	b := C.GoBytes(unsafe.Pointer(flags), (C.int)(C.strlen(flags)))
 

--- a/flipt-client-java/src/main/java/io/flipt/client/FliptEvaluationClient.java
+++ b/flipt-client-java/src/main/java/io/flipt/client/FliptEvaluationClient.java
@@ -24,17 +24,17 @@ public class FliptEvaluationClient {
 
     Pointer initialize_engine(String namespace, String opts);
 
-    String evaluate_boolean(Pointer engine, String evaluation_request);
+    Pointer evaluate_boolean(Pointer engine, String evaluation_request);
 
-    String evaluate_variant(Pointer engine, String evaluation_request);
+    Pointer evaluate_variant(Pointer engine, String evaluation_request);
 
-    String evaluate_batch(Pointer engine, String batch_evaluation_request);
+    Pointer evaluate_batch(Pointer engine, String batch_evaluation_request);
 
-    String list_flags(Pointer engine);
+    Pointer list_flags(Pointer engine);
 
     void destroy_engine(Pointer engine);
 
-    void destroy_string(String str);
+    void destroy_string(Pointer str);
   }
 
   private FliptEvaluationClient(String namespace, EngineOpts engineOpts)
@@ -136,12 +136,12 @@ public class FliptEvaluationClient {
         new InternalEvaluationRequest(flagKey, entityId, context);
 
     String evaluationRequestSerialized = this.objectMapper.writeValueAsString(evaluationRequest);
-    String value = CLibrary.INSTANCE.evaluate_variant(this.engine, evaluationRequestSerialized);
+    Pointer value = CLibrary.INSTANCE.evaluate_variant(this.engine, evaluationRequestSerialized);
 
     TypeReference<Result<VariantEvaluationResponse>> typeRef =
         new TypeReference<Result<VariantEvaluationResponse>>() {};
 
-    return this.objectMapper.readValue(value, typeRef);
+    return this.readValue(value, typeRef);
   }
 
   public Result<BooleanEvaluationResponse> evaluateBoolean(
@@ -150,11 +150,11 @@ public class FliptEvaluationClient {
         new InternalEvaluationRequest(flagKey, entityId, context);
 
     String evaluationRequestSerialized = this.objectMapper.writeValueAsString(evaluationRequest);
-    String value = CLibrary.INSTANCE.evaluate_boolean(this.engine, evaluationRequestSerialized);
+    Pointer value = CLibrary.INSTANCE.evaluate_boolean(this.engine, evaluationRequestSerialized);
 
     TypeReference<Result<BooleanEvaluationResponse>> typeRef =
         new TypeReference<Result<BooleanEvaluationResponse>>() {};
-    return this.objectMapper.readValue(value, typeRef);
+    return this.readValue(value, typeRef);
   }
 
   public Result<BatchEvaluationResponse> evaluateBatch(EvaluationRequest[] batchEvaluationRequests)
@@ -173,24 +173,33 @@ public class FliptEvaluationClient {
 
     String batchEvaluationRequestSerialized =
         this.objectMapper.writeValueAsString(evaluationRequests.toArray());
-    String value = CLibrary.INSTANCE.evaluate_batch(this.engine, batchEvaluationRequestSerialized);
+    Pointer value = CLibrary.INSTANCE.evaluate_batch(this.engine, batchEvaluationRequestSerialized);
 
     TypeReference<Result<BatchEvaluationResponse>> typeRef =
         new TypeReference<Result<BatchEvaluationResponse>>() {};
 
-    return this.objectMapper.readValue(value, typeRef);
+    return this.readValue(value, typeRef);
   }
 
   public Result<ArrayList<Flag>> listFlags() throws JsonProcessingException {
-    String value = CLibrary.INSTANCE.list_flags(this.engine);
+    Pointer value = CLibrary.INSTANCE.list_flags(this.engine);
 
     TypeReference<Result<ArrayList<Flag>>> typeRef =
         new TypeReference<Result<ArrayList<Flag>>>() {};
 
-    return this.objectMapper.readValue(value, typeRef);
+    return this.readValue(value, typeRef);
   }
 
   public void close() {
     CLibrary.INSTANCE.destroy_engine(this.engine);
+  }
+
+  private <T> T readValue(Pointer ptr, TypeReference<T> typeRef) throws JsonProcessingException {
+      try {
+        String value = ptr.getString(0, "UTF-8"); 
+        return this.objectMapper.readValue(value, typeRef);
+      } finally {
+          CLibrary.INSTANCE.destroy_string(ptr);
+      }
   }
 }

--- a/flipt-client-java/src/main/java/io/flipt/client/FliptEvaluationClient.java
+++ b/flipt-client-java/src/main/java/io/flipt/client/FliptEvaluationClient.java
@@ -195,11 +195,11 @@ public class FliptEvaluationClient {
   }
 
   private <T> T readValue(Pointer ptr, TypeReference<T> typeRef) throws JsonProcessingException {
-      try {
-        String value = ptr.getString(0, "UTF-8"); 
-        return this.objectMapper.readValue(value, typeRef);
-      } finally {
-          CLibrary.INSTANCE.destroy_string(ptr);
-      }
+    try {
+      String value = ptr.getString(0, "UTF-8");
+      return this.objectMapper.readValue(value, typeRef);
+    } finally {
+      CLibrary.INSTANCE.destroy_string(ptr);
+    }
   }
 }

--- a/flipt-client-java/src/main/java/io/flipt/client/FliptEvaluationClient.java
+++ b/flipt-client-java/src/main/java/io/flipt/client/FliptEvaluationClient.java
@@ -33,6 +33,8 @@ public class FliptEvaluationClient {
     String list_flags(Pointer engine);
 
     void destroy_engine(Pointer engine);
+
+    void destroy_string(String str);
   }
 
   private FliptEvaluationClient(String namespace, EngineOpts engineOpts)

--- a/flipt-client-python/flipt_client/__init__.py
+++ b/flipt-client-python/flipt_client/__init__.py
@@ -66,16 +66,19 @@ class FliptEvaluationClient:
         self.ffi_core.destroy_engine.argtypes = [ctypes.c_void_p]
 
         self.ffi_core.evaluate_variant.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-        self.ffi_core.evaluate_variant.restype = ctypes.c_char_p
+        self.ffi_core.evaluate_variant.restype = ctypes.POINTER(ctypes.c_char_p)
 
         self.ffi_core.evaluate_boolean.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-        self.ffi_core.evaluate_boolean.restype = ctypes.c_char_p
+        self.ffi_core.evaluate_boolean.restype = ctypes.POINTER(ctypes.c_char_p)
 
         self.ffi_core.evaluate_batch.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-        self.ffi_core.evaluate_batch.restype = ctypes.c_char_p
+        self.ffi_core.evaluate_batch.restype = ctypes.POINTER(ctypes.c_char_p)
 
         self.ffi_core.list_flags.argtypes = [ctypes.c_void_p]
-        self.ffi_core.list_flags.restype = ctypes.c_char_p
+        self.ffi_core.list_flags.restype = ctypes.POINTER(ctypes.c_char_p)
+
+        self.ffi_core.destroy_string.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+        self.ffi_core.destroy_string.restype = ctypes.c_void_p
 
         ns = namespace.encode("utf-8")
 
@@ -99,8 +102,9 @@ class FliptEvaluationClient:
             ),
         )
 
-        bytes_returned = ctypes.c_char_p(response).value
+        bytes_returned = ctypes.cast(response, ctypes.c_char_p).value
         variant_result = VariantResult.model_validate_json(bytes_returned)
+        self.ffi_core.destroy_string(response)
         return variant_result
 
     def evaluate_boolean(
@@ -113,8 +117,9 @@ class FliptEvaluationClient:
             ),
         )
 
-        bytes_returned = ctypes.c_char_p(response).value
+        bytes_returned = ctypes.cast(response, ctypes.c_char_p).value
         boolean_result = BooleanResult.model_validate_json(bytes_returned)
+        self.ffi_core.destroy_string(response)
         return boolean_result
 
     def evaluate_batch(self, requests: List[EvaluationRequest]) -> BatchResult:
@@ -140,15 +145,17 @@ class FliptEvaluationClient:
             self.engine, json_string.encode("utf-8")
         )
 
-        bytes_returned = ctypes.c_char_p(response).value
+        bytes_returned = ctypes.cast(response, ctypes.c_char_p).value
         batch_result = BatchResult.model_validate_json(bytes_returned)
+        self.ffi_core.destroy_string(response)
         return batch_result
 
     def list_flags(self) -> ListFlagsResult:
         response = self.ffi_core.list_flags(self.engine)
 
-        bytes_returned = ctypes.c_char_p(response).value
+        bytes_returned = ctypes.cast(response, ctypes.c_char_p).value
         result = ListFlagsResult.model_validate_json(bytes_returned)
+        self.ffi_core.destroy_string(response)
         return result
 
 

--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -323,6 +323,6 @@ pub unsafe extern "C" fn destroy_engine(engine_ptr: *mut c_void) {
 /// This function will take in a pointer to the string and free the memory.
 /// See Rust the safety section in CString::from_raw.
 #[no_mangle]
-pub unsafe extern "C" fn destroy_string(ptr: *const c_char) {
+pub unsafe extern "C" fn destroy_string(ptr: *mut c_char) {
     let _ = CString::from_raw(ptr);
 }

--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -317,3 +317,12 @@ pub unsafe extern "C" fn destroy_engine(engine_ptr: *mut c_void) {
 
     drop(Box::from_raw(engine_ptr as *mut Engine));
 }
+
+/// # Safety
+///
+/// This function will take in a pointer to the string and free the memory.
+/// See Rust the safety section in CString::from_raw.
+#[no_mangle]
+pub unsafe extern "C" fn destroy_string(ptr: *const c_char) {
+    let _ = CString::from_raw(ptr);
+}


### PR DESCRIPTION
todos:
- [x] create the function to clean the pointer for  CString::into_raw()
- [x] update the clients to return the const *char to ffi for memory cleanup

> [CString::into_raw](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.into_raw) The pointer which this function returns must be returned to Rust and reconstituted using [CString::from_raw](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.from_raw) to be properly deallocated. Specifically, one should not use the standard C free() function to deallocate this string.