### PR TITLE
fix(flipt-evaluation): increment bucket search index by one

### DIFF
--- a/flipt-evaluation/src/lib.rs
+++ b/flipt-evaluation/src/lib.rs
@@ -411,7 +411,7 @@ where
 
             buckets.sort();
 
-            let index = match buckets.binary_search(&(bucket+1 as i32)) {
+            let index = match buckets.binary_search(&(bucket as i32 + 1)) {
                 Ok(idx) => idx,
                 Err(idx) => idx,
             };

--- a/flipt-evaluation/src/lib.rs
+++ b/flipt-evaluation/src/lib.rs
@@ -411,7 +411,7 @@ where
 
             buckets.sort();
 
-            let index = match buckets.binary_search(&(bucket as i32)) {
+            let index = match buckets.binary_search(&(bucket+1 as i32)) {
                 Ok(idx) => idx,
                 Err(idx) => idx,
             };


### PR DESCRIPTION
See: https://github.com/flipt-io/flipt/issues/2890#issuecomment-2016430657

This brings our Rust implementation inline with our Go implementation of search.