### PR TITLE
fix(flipt-evaluation): stop casting crc32 checksum as i32

### DIFF
--- a/flipt-evaluation/src/lib.rs
+++ b/flipt-evaluation/src/lib.rs
@@ -478,8 +478,7 @@ where
                         evaluation_request.entity_id, evaluation_request.flag_key
                     )
                     .as_bytes(),
-                ) as i32
-                    % 100) as f32;
+                ) % 100) as f32;
 
                 if normalized_value < threshold.percentage {
                     return Ok(BooleanEvaluationResponse {


### PR DESCRIPTION
Fixes https://github.com/flipt-io/flipt/issues/2890

@markphelps observed some suspicious casting during evaluation https://github.com/flipt-io/flipt/issues/2890#issuecomment-2016474104

After a bit of reproduction we demonstrated a large error rate when the resulting hash is cast as i32.
`crc32fast::hash(...)` produces a `u32`, which when cast as an `i32` can and does (I checked) wrap around and become negative. This appears to be the cause to the unexpected distribution.

