### PR TITLE
chore: Update .gitignore

### DIFF
--- a/flipt-client-go/.gitignore
+++ b/flipt-client-go/.gitignore
@@ -16,5 +16,3 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-
-ext/


### PR DESCRIPTION
Try to fix #187

I think this may be causing the Go client sdk to skip the header files and lib files when synced to the new repo