### PR TITLE
fix(ffi): strip release libraries for real

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "2"
 members = ["./flipt-engine-ffi", "./flipt-evaluation"]
+
+[profile.release]
+strip = true

--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -25,6 +25,3 @@ mockall = "0.12.1"
 [lib]
 name = "fliptengine"
 crate-type = ["rlib", "dylib"]
-
-[profile.release]
-strip = true


### PR DESCRIPTION
See: https://github.com/flipt-io/flipt-client-sdks/issues/187#issuecomment-2021141830

https://doc.rust-lang.org/cargo/reference/profiles.html#profiles

> Cargo only looks at the profile settings in the Cargo.toml manifest at the root of the workspace. Profile settings defined in dependencies will be ignored.

Which now I understand / see these warnings: https://github.com/flipt-io/flipt-client-sdks/actions/runs/8438700013/job/23111503420#step:5:8

We'll have to create a new engine release and new Go SDK release once this is merged.