### PR TITLE
fix(ffi): prevent fatal error if there is the connection error during client creation

### DIFF
--- a/flipt-engine-ffi/src/evaluator/mod.rs
+++ b/flipt-engine-ffi/src/evaluator/mod.rs
@@ -26,9 +26,10 @@ where
     P: Parser + Send,
 {
     pub fn new_snapshot_evaluator(namespace: &str, parser: P) -> Result<Self, Error> {
-        let doc = parser.parse(namespace)?;
-        let snap = Snapshot::build(namespace, doc)?;
-        Ok(Evaluator::new(namespace, parser, snap))
+        let snap = Snapshot::build(namespace, Document::default())?;
+        let mut e = Evaluator::new(namespace, parser, snap);
+        e.replace_snapshot();
+        Ok(e)
     }
 
     pub fn replace_snapshot(&mut self) {


### PR DESCRIPTION
Sooner or later this should be fixed. 
```
thread '<unnamed>' panicked at flipt-engine-ffi/src/lib.rs:205:74:
called `Result::unwrap()` on an `Err` value: Server("failed to make request: error sending request for url (http://localhost:8080/internal/v1/evaluation/snapshot/namespace/default)")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
SIGABRT: abort
```

The idea is to start with empty state and use `replace_snapshot` logic to fill it.  If the service isn't available the error will be returned until the service is live and state is updated.