### PR TITLE
chore: add back wasm to release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,10 @@
     "flipt-engine-ffi": {
       "component": "flipt-engine-ffi",
       "release-type": "rust"
+    },
+    "flipt-engine-wasm": {
+      "component": "flipt-engine-wasm",
+      "release-type": "rust"
     }
   }
 }


### PR DESCRIPTION
idk why but I'd like to have the flipt-engine-wasm component version handled by release-please as well