### PR TITLE
No explicit Flipt namespace

### DIFF
--- a/flipt-client-ruby/lib/flipt_client.rb
+++ b/flipt-client-ruby/lib/flipt_client.rb
@@ -56,8 +56,8 @@ module Flipt
       @namespace = namespace
 
       # set default no auth if not provided
-      authentication = opts.fetch(:authentication, Flipt::NoAuthentication.new)
-      unless authentication.is_a?(Flipt::AuthenticationStrategy)
+      authentication = opts.fetch(:authentication, NoAuthentication.new)
+      unless authentication.is_a?(AuthenticationStrategy)
         raise ArgumentError,
               'invalid authentication strategy'
       end


### PR DESCRIPTION
## Issue

Hello,

When using [flipt-grpc-ruby](https://github.com/flipt-io/flipt-grpc-ruby/tree/v1.12.0) and flipt_client together, there is an issue where the `Flipt::EvaluationClient` cannot be instantiated. This occurs because flipt-grpc-ruby creates a namespace called [`Flipt::Flipt`](https://github.com/flipt-io/flipt-grpc-ruby/blob/v1.12.0/lib/flipt_services_pb.rb#L8), causing the `Flipt::NoAuthentication` declared in the context of `Flipt::EvaluationClient` to be misinterpreted as `Flipt::Flipt::NoAuthentication`.

## Solution
To resolve this issue, I removed the `Flipt::` prefix, ensuring that the correct `NoAuthentication` class is selected. This allows `Flipt::EvaluationClient` to be instantiated successfully when using flipt-grpc-ruby and flipt_client together.

## Changes
Removed the `Flipt::` prefix to resolve the issue where `Flipt::NoAuthentication` declared in the context of `Flipt::EvaluationClient` was misinterpreted as `Flipt::Flipt::NoAuthentication`.

## Testing in my local environment

### Before changes

```rb
[1] pry(main)> require "flipt_services_pb"
=> true
[2] pry(main)> Flipt::Flipt
=> Flipt::Flipt
[3] pry(main)> Flipt::EvaluationClient.new("default", url: ENV.fetch("FLIPT_URL"))
NameError: uninitialized constant Flipt::Flipt::NoAuthentication
from /usr/local/bundle/gems/flipt_client-0.5.0/lib/flipt_client.rb:58:in `initialize'
```

### After changed

```rb
[1] pry(main)> require "flipt_services_pb"                   
=> true        
[2] pry(main)> Flipt::Flipt                                                       
=> Flipt::Flipt                                                                                                         
[3] pry(main)> Flipt::EvaluationClient.new("default", url: ENV.fetch("FLIPT_URL"))   
=> #<Flipt::EvaluationClient:0x0000ffff7f702810 @engine=#<FFI::Pointer address=0x0000ffff84167550>, @namespace="default">
```