### PR TITLE
chore: bump ruby sdk version

### DIFF
--- a/flipt-client-ruby/lib/flipt_client/version.rb
+++ b/flipt-client-ruby/lib/flipt_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flipt
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
for release