### PR TITLE
fix: node sdk paths

### DIFF
--- a/flipt-client-node/package-lock.json
+++ b/flipt-client-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flipt-io/flipt-client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flipt-io/flipt-client",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@2060.io/ffi-napi": "^4.0.9",

--- a/flipt-client-node/package.json
+++ b/flipt-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipt-io/flipt-client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Flipt Client Evaluation SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -8,8 +8,7 @@
   "author": "Flipt Devs <dev@flipt.io>",
   "license": "MIT",
   "files": [
-    "dist",
-    "ext"
+    "dist"
   ],
   "scripts": {
     "fmt": "prettier --config .prettierrc 'src/**/*.ts' --write",

--- a/flipt-client-node/package.json
+++ b/flipt-client-node/package.json
@@ -8,7 +8,8 @@
   "author": "Flipt Devs <dev@flipt.io>",
   "license": "MIT",
   "files": [
-    "dist"
+    "dist",
+    "ext"
   ],
   "scripts": {
     "fmt": "prettier --config .prettierrc 'src/**/*.ts' --write",

--- a/flipt-client-node/tsconfig.json
+++ b/flipt-client-node/tsconfig.json
@@ -4,12 +4,12 @@
     "target": "es2019",
     "declaration": true,
     "outDir": "dist",
+    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true
   },
   "include": [
     "src/**/*",
-    "__tests__"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Fixes packaging issue where `src` was getting put at `dist/src` which would then fail to load as well as fail relative imports of engine