### PR TITLE
ci: switch to googleapis/release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,6 @@ jobs:
           private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
           installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
 
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.generate_token.outputs.token}}


### PR DESCRIPTION
Google has deprecated [google-github-actions/release-please-action ](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file)repo and moved all activity into new repo.

https://github.com/flipt-io/flipt-client-sdks/actions/runs/9067151077/job/24911609980