### PR TITLE
feat: add support to python 3.10

### DIFF
--- a/flipt-client-python/pyproject.toml
+++ b/flipt-client-python/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 include = [{ path = "ext/**/*" }, { path = "README.md" }]
 name = "flipt-client"
-version = "0.7.0"
+version = "0.8.0"
 description = "Flipt Client Evaluation SDK"
 authors = ["Flipt Devs <dev@flipt.io>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ license = "MIT"
 repository = "https://github.com/flipt-io/flipt-client-sdks"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.10"
 pydantic = "<3.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
**Validation**
Ran tests locally and they all passed:
```
dagger run go run ./test -sdks python
```

<img width="772" alt="Screenshot 2024-06-19 at 15 55 55" src="https://github.com/flipt-io/flipt-client-sdks/assets/4041238/7dc23e9f-02f2-4bdd-b868-9e6889ae8b16">
