### PR TITLE
feat: support etags in clients

### DIFF
--- a/flipt-client-browser/src/models.ts
+++ b/flipt-client-browser/src/models.ts
@@ -1,5 +1,5 @@
-export interface fetcher {
-  (): Promise<Response>;
+export interface IFetcher {
+  ({ etag }: { etag?: string }): Promise<Response>;
 }
 
 export interface AuthenticationStrategy {}
@@ -16,7 +16,7 @@ export interface EngineOpts {
   url?: string;
   authentication?: AuthenticationStrategy;
   reference?: string;
-  fetcher?: fetcher;
+  fetcher?: IFetcher;
 }
 
 export interface EvaluationRequest {

--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -21,6 +21,7 @@ path = "../flipt-evaluation"
 
 [dev-dependencies]
 mockall = "0.12.1"
+mockito = "1.4.0"
 
 [lib]
 name = "fliptengine"

--- a/flipt-engine-ffi/src/evaluator/mod.rs
+++ b/flipt-engine-ffi/src/evaluator/mod.rs
@@ -36,7 +36,11 @@ where
     pub fn replace_snapshot(&mut self) {
         match self.parser.parse(&self.namespace) {
             Ok(doc) => {
-                match Snapshot::build(&self.namespace, doc) {
+                // if doc is none then return, nothing to do
+                if doc.is_none() {
+                    return;
+                }
+                match Snapshot::build(&self.namespace, doc.unwrap()) {
                     Ok(s) => {
                         self.replace_store(s, None);
                     }
@@ -139,7 +143,7 @@ mod tests {
     mock! {
         pub Parser{}
         impl parser::Parser for Parser {
-            fn parse(&self, namespace: &str) -> Result<source::Document, Error>;
+            fn parse(&mut self, namespace: &str) -> Result<Option<source::Document>, Error>;
         }
     }
 
@@ -182,7 +186,9 @@ mod tests {
     #[test]
     fn test_parser_with_empty_snapshot() {
         let mut parser = MockParser::new();
-        parser.expect_parse().returning(|_| Ok(Document::default()));
+        parser
+            .expect_parse()
+            .returning(|_| Ok(Some(Document::default())));
         let evaluator =
             Evaluator::new_snapshot_evaluator("namespace", parser).expect("expect valid evaluator");
 
@@ -221,7 +227,9 @@ mod tests {
     #[test]
     fn test_list_flags_from_another_namespace() {
         let mut parser = MockParser::new();
-        parser.expect_parse().returning(|_| Ok(Document::default()));
+        parser
+            .expect_parse()
+            .returning(|_| Ok(Some(Document::default())));
         let mut evaluator =
             Evaluator::new_snapshot_evaluator("namespace", parser).expect("expect valid evaluator");
         evaluator.replace_store(Snapshot::empty("other"), None);

--- a/flipt-engine-ffi/src/evaluator/mod.rs
+++ b/flipt-engine-ffi/src/evaluator/mod.rs
@@ -130,6 +130,7 @@ where
         batch_evaluation(&self.store, &self.namespace, requests)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -157,6 +158,7 @@ mod tests {
             }
         }
     }
+
     #[test]
     fn test_parser_with_error() {
         let expected_error = "server error: can't connect";
@@ -222,6 +224,17 @@ mod tests {
             response,
             "invalid request: failed to get flag information namespace/foo",
         );
+    }
+
+    #[test]
+    fn test_parser_with_no_snapshot() {
+        let mut parser = MockParser::new();
+        parser.expect_parse().returning(|_| Ok(None));
+        let evaluator =
+            Evaluator::new_snapshot_evaluator("namespace", parser).expect("expect valid evaluator");
+
+        let response = evaluator.list_flags();
+        assert!(response.is_ok());
     }
 
     #[test]

--- a/flipt-evaluation/src/parser/mod.rs
+++ b/flipt-evaluation/src/parser/mod.rs
@@ -1,5 +1,5 @@
 pub trait Parser {
-    fn parse(&self, namespace: &str) -> Result<source::Document, Error>;
+    fn parse(&mut self, namespace: &str) -> Result<Option<source::Document>, Error>;
 }
 
 #[cfg(test)]
@@ -24,7 +24,7 @@ impl TestParser {
 
 #[cfg(test)]
 impl Parser for TestParser {
-    fn parse(&self, _: &str) -> Result<source::Document, Error> {
+    fn parse(&mut self, _: &str) -> Result<Option<source::Document>, Error> {
         let f = match &self.path {
             Some(path) => path.to_owned(),
             None => {
@@ -41,6 +41,6 @@ impl Parser for TestParser {
             Err(e) => return Err(Error::InvalidJSON(e.to_string())),
         };
 
-        Ok(document)
+        Ok(Some(document))
     }
 }

--- a/flipt-evaluation/src/store/mod.rs
+++ b/flipt-evaluation/src/store/mod.rs
@@ -281,10 +281,10 @@ mod tests {
 
     #[test]
     fn test_snapshot() {
-        let tp = TestParser::new();
+        let mut tp = TestParser::new();
         let doc = tp.parse("default").unwrap();
 
-        let snapshot = Snapshot::build("default", doc).unwrap();
+        let snapshot = Snapshot::build("default", doc.unwrap()).unwrap();
 
         let flag_variant = snapshot
             .get_flag("default", "flag1")


### PR DESCRIPTION
Fixes: #294 

Re: https://github.com/flipt-io/flipt/pull/3248

Supports `if-none-match/etag` headers in clients so we don't do the work of parsing/creating a new snapshot if no data has changed for this namespace

## TODO

- [x] add tests