### PR TITLE
fix(go): return errors correctly from Go client

### DIFF
--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -14,8 +14,11 @@ import "C"
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"unsafe"
 )
+
+const statusSuccess = "success"
 
 // Client wraps the functionality of making variant and boolean evaluation of Flipt feature flags.
 type Client struct {
@@ -128,7 +131,10 @@ func (e *Client) EvaluateVariant(_ context.Context, flagKey, entityID string, ev
 		return nil, err
 	}
 
-	return vr, nil
+	if vr.Status == statusSuccess {
+		return vr, nil
+	}
+	return nil, errors.New(vr.ErrorMessage)
 }
 
 // EvaluateBoolean performs evaluation for a boolean flag.
@@ -157,7 +163,11 @@ func (e *Client) EvaluateBoolean(_ context.Context, flagKey, entityID string, ev
 		return nil, err
 	}
 
-	return br, nil
+	if br.Status == statusSuccess {
+		return br, nil
+	}
+
+	return nil, errors.New(br.ErrorMessage)
 }
 
 // EvaluateBatch performs evaluation for a batch of flags.
@@ -192,7 +202,11 @@ func (e *Client) EvaluateBatch(_ context.Context, requests []*EvaluationRequest)
 		return nil, err
 	}
 
-	return br, nil
+	if br.Status == statusSuccess {
+		return br, nil
+	}
+
+	return nil, errors.New(br.ErrorMessage)
 }
 
 func (e *Client) ListFlags(_ context.Context) (*ListFlagsResult, error) {
@@ -207,7 +221,10 @@ func (e *Client) ListFlags(_ context.Context) (*ListFlagsResult, error) {
 		return nil, err
 	}
 
-	return fl, nil
+	if fl.Status == statusSuccess {
+		return fl, nil
+	}
+	return nil, errors.New(fl.ErrorMessage)
 }
 
 // Close cleans up the allocated engine as it was initialized in the constructor.

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -134,6 +134,7 @@ func (e *Client) EvaluateVariant(_ context.Context, flagKey, entityID string, ev
 	if vr.Status == statusSuccess {
 		return vr, nil
 	}
+
 	return nil, errors.New(vr.ErrorMessage)
 }
 
@@ -224,6 +225,7 @@ func (e *Client) ListFlags(_ context.Context) (*ListFlagsResult, error) {
 	if fl.Status == statusSuccess {
 		return fl, nil
 	}
+
 	return nil, errors.New(fl.ErrorMessage)
 }
 

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -35,7 +35,11 @@ func init() {
 }
 
 func TestInvalidAuthentication(t *testing.T) {
-	_, err := flipt.NewClient(flipt.WithURL(fliptUrl), flipt.WithClientTokenAuthentication("invalid"))
+	client, err := flipt.NewClient(flipt.WithURL(fliptUrl), flipt.WithClientTokenAuthentication("invalid"))
+	require.NoError(t, err)
+	_, err = client.EvaluateVariant(context.TODO(), "flag1", "someentity", map[string]string{
+		"fizz": "buzz",
+	})
 	assert.EqualError(t, err, "invalid authentication")
 }
 

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -40,7 +40,7 @@ func TestInvalidAuthentication(t *testing.T) {
 	_, err = client.EvaluateVariant(context.TODO(), "flag1", "someentity", map[string]string{
 		"fizz": "buzz",
 	})
-	require.EqualError(t, err, "server error: response: HTTP status client error (401 Unauthorized) for url (http://flipt:8080/internal/v1/evaluation/snapshot/namespace/default)")
+	assert.EqualError(t, err, "server error: response: HTTP status client error (401 Unauthorized) for url (http://flipt:8080/internal/v1/evaluation/snapshot/namespace/default)")
 }
 
 func TestVariant(t *testing.T) {
@@ -126,12 +126,12 @@ func TestVariantFailure(t *testing.T) {
 	_, err := evaluationClient.EvaluateVariant(context.TODO(), "nonexistent", "someentity", map[string]string{
 		"fizz": "buzz",
 	})
-	require.EqualError(t, err, "invalid request: failed to get flag information default/nonexistent")
+	assert.EqualError(t, err, "invalid request: failed to get flag information default/nonexistent")
 }
 
 func TestBooleanFailure(t *testing.T) {
 	_, err := evaluationClient.EvaluateBoolean(context.TODO(), "nonexistent", "someentity", map[string]string{
 		"fizz": "buzz",
 	})
-	require.EqualError(t, err, "invalid request: failed to get flag information default/nonexistent")
+	assert.EqualError(t, err, "invalid request: failed to get flag information default/nonexistent")
 }

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -10,15 +10,19 @@ import (
 	flipt "go.flipt.io/flipt-client"
 )
 
-var evaluationClient *flipt.Client
+var (
+	evaluationClient *flipt.Client
+	fliptUrl         string
+	authToken        string
+)
 
 func init() {
-	fliptUrl := os.Getenv("FLIPT_URL")
+	fliptUrl = os.Getenv("FLIPT_URL")
 	if fliptUrl == "" {
 		panic("set FLIPT_URL")
 	}
 
-	authToken := os.Getenv("FLIPT_AUTH_TOKEN")
+	authToken = os.Getenv("FLIPT_AUTH_TOKEN")
 	if authToken == "" {
 		panic("set FLIPT_AUTH_TOKEN")
 	}
@@ -28,6 +32,11 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func TestInvalidAuthentication(t *testing.T) {
+	_, err := flipt.NewClient(flipt.WithURL(fliptUrl), flipt.WithClientTokenAuthentication("invalid"))
+	assert.EqualError(t, err, "invalid authentication")
 }
 
 func TestVariant(t *testing.T) {

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -37,10 +37,13 @@ func init() {
 func TestInvalidAuthentication(t *testing.T) {
 	client, err := flipt.NewClient(flipt.WithURL(fliptUrl), flipt.WithClientTokenAuthentication("invalid"))
 	require.NoError(t, err)
-	_, err = client.EvaluateVariant(context.TODO(), "flag1", "someentity", map[string]string{
+	variant, err := client.EvaluateVariant(context.TODO(), "flag1", "someentity", map[string]string{
 		"fizz": "buzz",
 	})
-	assert.EqualError(t, err, "invalid authentication")
+	require.NoError(t, err)
+	assert.Nil(t, variant.Result)
+	assert.Equal(t, "failure", variant.Status)
+	assert.Equal(t, "invalid authentication", variant.ErrorMessage)
 }
 
 func TestVariant(t *testing.T) {

--- a/test/main.go
+++ b/test/main.go
@@ -144,9 +144,9 @@ func getTestDependencies(_ context.Context, client *dagger.Client, hostDirectory
 		WithUser("flipt").
 		WithEnvVariable("FLIPT_STORAGE_TYPE", "local").
 		WithEnvVariable("FLIPT_STORAGE_LOCAL_PATH", "/var/data/flipt").
-		WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_ENABLED", "1").
+		WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_ENABLED", "true").
 		WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_BOOTSTRAP_TOKEN", "secret").
-		WithEnvVariable("FLIPT_AUTHENTICATION_REQUIRED", "1").
+		WithEnvVariable("FLIPT_AUTHENTICATION_REQUIRED", "true").
 		WithExposedPort(8080)
 
 	return flipt, testArgs{


### PR DESCRIPTION
Trying to test invalid authentication errors from #347 