### PR TITLE
chore: add missing dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,36 @@ updates:
       # kodiak `merge.automerge_label`
       - "automerge"
 
+  - package-ecosystem: "gradle"
+    directory: "/flipt-client-java"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      # kodiak `merge.automerge_label`
+      - "automerge"
+
+  - package-ecosystem: "bundler"
+    directory: "/flipt-client-ruby"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      # kodiak `merge.automerge_label`
+      - "automerge"
+
+  - package-ecosystem: "pub"
+    directory: "/flipt-client-dart"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      # kodiak `merge.automerge_label`
+      - "automerge"
+
   - package-ecosystem: "cargo"
     directory: "/flipt-engine-ffi"
     schedule:


### PR DESCRIPTION
adds missing dependabot updates for:

- ruby
- dart
- java

