### PR TITLE
chore(ffi): replace openssl with rust-native-tls crate

### DIFF
--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -13,8 +13,8 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }
 reqwest = { version = "0.12.2", features = ["json", "blocking"] }
 tokio = { version = "1.33.0", features = ["full"] }
+native-tls = { version = "0.2", features = ["vendored"] }
 futures = "0.3"
-openssl = { version = "0.10", features = ["vendored"] }
 thiserror = "1.0.63"
 
 [dependencies.flipt-evaluation]


### PR DESCRIPTION
`reqwest` uses `rust-native-tls` for tls. It requires openssl for linux but nothing for Windows or macOS. Per their suggestion for linux native-tls-vendored feature should be used to compile a copy of OpenSSL. This change reduces compilation time during the development on macOS