### PR TITLE
fix(java): loading lib on arm

### DIFF
--- a/.github/workflows/package-browser-sdk.yml
+++ b/.github/workflows/package-browser-sdk.yml
@@ -8,24 +8,26 @@ permissions:
 
 env:
   NPM_API_KEY: ${{ secrets.NPM_API_KEY }}
+  GO_VERSION: "1.22"
+  DAGGER_VERSION: "0.12.3"
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.3"
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
           cache: true
 
       - name: Install Dagger
         run: |
           cd /usr/local
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=$DAGGER_VERSION sh
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAGGER_VERSION }} sh
 
       - name: Build Individual SDK(s)
         run: |

--- a/.github/workflows/package-ffi-sdks.yml
+++ b/.github/workflows/package-ffi-sdks.yml
@@ -29,6 +29,8 @@ env:
   MAVEN_PUBLISH_REGISTRY_URL: ${{ secrets.MAVEN_PUBLISH_REGISTRY_URL }}
   PGP_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
   PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+  GO_VERSION: "1.22"
+  DAGGER_VERSION: "0.12.3"
 
 jobs:
   build:
@@ -36,19 +38,18 @@ jobs:
     env:
       ENGINE_TAG: ${{ inputs.engine-tag }}
     steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.3"
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
           cache: true
 
       - name: Install Dagger
         run: |
           cd /usr/local
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=$DAGGER_VERSION sh
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAGGER_VERSION }} sh
 
       - name: Get Latest Engine Version
         run: |

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  GO_VERSION: "1.22"
+  DAGGER_VERSION: "0.12.3"
+
 jobs:
   test:
     name: Integration Tests
@@ -16,14 +20,14 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.3"
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
           cache: true
 
       - name: Install Dagger
         run: |
           cd /usr/local
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=$DAGGER_VERSION sh
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAGGER_VERSION }} sh
 
       - name: Run Integration Tests
         run: |

--- a/package/ffi/main.go
+++ b/package/ffi/main.go
@@ -395,7 +395,7 @@ func javaBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger
 
 	rename := map[string]string{
 		"linux_x86_64":  "linux-x86-64",
-		"linux_arm64":   "linux-arm",
+		"linux_arm64":   "linux-aarch64",
 		"darwin_x86_64": "darwin-x86-64",
 		"darwin_arm64":  "darwin-aarch64",
 	}
@@ -411,7 +411,6 @@ func javaBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger
 		WithDirectory("/src/src/main/resources", hostDirectory.Directory("tmp"), dagger.ContainerWithDirectoryOpts{
 			Exclude: defaultExclude,
 		}).
-		WithFile("/src/main/resources/flipt_engine.h", hostDirectory.File("flipt-engine-ffi/include/flipt_engine.h")).
 		WithWorkdir("/src").
 		WithExec([]string{"gradle", "-x", "test", "build"})
 

--- a/test/main.go
+++ b/test/main.go
@@ -240,15 +240,15 @@ func javaTests(ctx context.Context, client *dagger.Client, flipt *dagger.Contain
 	path := "x86-64"
 
 	if args.arch == "arm64" {
-		path = "arm"
+		path = "aarch64"
 	}
 
 	_, err := client.Pipeline("java").Container().From("gradle:8.5.0-jdk11").
-		WithWorkdir("/src").
 		WithDirectory("/src", args.hostDir.Directory("flipt-client-java"), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"./.idea/"},
+			Exclude: []string{"./.idea/", ".gradle/", "build/"},
 		}).
 		WithFile(fmt.Sprintf("/src/src/main/resources/linux-%s/libfliptengine.so", path), args.libFile).
+		WithWorkdir("/src").
 		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").


### PR DESCRIPTION
When I run `dagger run go run ./test --sdks=java` on main (on ARM machine) I get:

```
> Task :test FAILED

TestFliptEvaluationClient > initializationError FAILED
    java.lang.UnsatisfiedLinkError at TestFliptEvaluationClient.java:25
```

When I run with this fix I get a successful test passing

