### PR TITLE
feat: add list flags to wasm/node SDK

### DIFF
--- a/flipt-client-node/__tests__/evaluation.test.ts
+++ b/flipt-client-node/__tests__/evaluation.test.ts
@@ -127,4 +127,10 @@ describe('FliptEvaluationClient', () => {
       'invalid request: failed to get flag information default/nonexistent'
     );
   });
+
+  test('list flags', () => {
+    const flags = client.listFlags();
+    expect(flags).toBeDefined();
+    expect(flags.length).toBe(2);
+  });
 });

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -13,7 +13,9 @@ import {
   BooleanEvaluationResponse,
   BatchEvaluationResponse,
   ErrorEvaluationResponse,
-  EvaluationResponse
+  EvaluationResponse,
+  Flag,
+  ListFlagsResult
 } from './models';
 
 export class FliptEvaluationClient {
@@ -258,6 +260,26 @@ export class FliptEvaluationClient {
       responses,
       requestDurationMillis
     };
+  }
+
+  public listFlags(): Flag[] {
+    const listFlagsResult: ListFlagsResult | null = this.engine.list_flags();
+
+    if (listFlagsResult === null) {
+      throw new Error('Failed to list flags');
+    }
+
+    const flags = deserialize<ListFlagsResult>(listFlagsResult);
+
+    if (flags.status === 'failure') {
+      throw new Error(flags.errorMessage);
+    }
+
+    if (!flags.result) {
+      throw new Error('Failed to list flags');
+    }
+
+    return flags.result.map(deserialize<Flag>);
   }
 
   public close() {

--- a/flipt-client-node/src/models.ts
+++ b/flipt-client-node/src/models.ts
@@ -210,6 +210,12 @@ export interface BooleanResult extends Result<BooleanEvaluationResponse> {}
  */
 export interface BatchResult extends Result<BatchEvaluationResponse> {}
 
+/**
+ * Represents a specialized result object for listing flags, extending
+ * the generic Result interface with a specific type ListFlagsResponse.
+ */
+export interface ListFlagsResult extends Result<Flag[]> {}
+
 export interface Result<T> {
   /** Status of the result - `success` or `failure`. */
   status: string;

--- a/flipt-engine-wasm/src/lib.rs
+++ b/flipt-engine-wasm/src/lib.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 
 use fliptevaluation::{
     batch_evaluation, boolean_evaluation, error::Error, models::source, store::Snapshot,
-    variant_evaluation,
+    store::Store, variant_evaluation,
 };
 use serde::{Deserialize, Serialize};
 
@@ -139,6 +139,12 @@ impl Engine {
 
         let response = JsResponse::from(result);
 
+        Ok(serde_wasm_bindgen::to_value(&response)?)
+    }
+
+    pub fn list_flags(&self) -> Result<JsValue, JsValue> {
+        let flags = self.store.list_flags(&self.namespace);
+        let response = JsResponse::from(Ok(flags));
         Ok(serde_wasm_bindgen::to_value(&response)?)
     }
 }


### PR DESCRIPTION
- Adds list flags support to wasm engine
- Adds list flags back to node SDK

## TODO (another PR)

- Add list flags to browser SDK