### PR TITLE
refactor: browser argument casing + list flags

### DIFF
--- a/flipt-client-browser/README.md
+++ b/flipt-client-browser/README.md
@@ -22,14 +22,14 @@ import { FliptEvaluationClient } from '@flipt-io/flipt-client-browser';
 // {
 //  "url": "http://localhost:8080",
 //  "authentication": {
-//    "client_token": "secret"
+//    "clientToken": "secret"
 //  }
 // }
 //
 const fliptEvaluationClient = await FliptEvaluationClient.init('default', {
   url: 'http://localhost:8080',
   authentication: {
-    client_token
+    clientToken
   }
 });
 
@@ -69,7 +69,7 @@ The fetcher can be passed in as an argument to the `FliptEvaluationClient` initi
 const fliptEvaluationClient = await FliptEvaluationClient.init('default', {
   url: 'http://localhost:8080',
   authentication: {
-    client_token
+    clientToken
   },
   fetcher: customFetcher
 });

--- a/flipt-client-browser/__tests__/evaluation.test.js
+++ b/flipt-client-browser/__tests__/evaluation.test.js
@@ -23,7 +23,7 @@ describe('FliptEvaluationClient', () => {
     client = await flipt.FliptEvaluationClient.init('default', {
       url: fliptUrl,
       authentication: {
-        client_token: authToken
+        clientToken: authToken
       }
     });
   });
@@ -33,11 +33,11 @@ describe('FliptEvaluationClient', () => {
       fizz: 'buzz'
     });
 
-    expect(variant.flag_key).toEqual('flag1');
+    expect(variant.flagKey).toEqual('flag1');
     expect(variant.match).toEqual(true);
     expect(variant.reason).toEqual('MATCH_EVALUATION_REASON');
-    expect(variant.segment_keys).toContain('segment1');
-    expect(variant.variant_key).toContain('variant1');
+    expect(variant.segmentKeys).toContain('segment1');
+    expect(variant.variantKey).toContain('variant1');
   });
 
   test('boolean', () => {
@@ -76,32 +76,32 @@ describe('FliptEvaluationClient', () => {
       fizz: 'buzz'
     });
 
-    expect(variant.flag_key).toEqual('flag1');
+    expect(variant.flagKey).toEqual('flag1');
     expect(variant.match).toEqual(true);
     expect(variant.reason).toEqual('MATCH_EVALUATION_REASON');
-    expect(variant.segment_keys).toContain('segment1');
-    expect(variant.variant_key).toContain('variant1');
+    expect(variant.segmentKeys).toContain('segment1');
+    expect(variant.variantKey).toContain('variant1');
   });
 
   test('batch', () => {
     const batch = client.evaluateBatch([
       {
-        flag_key: 'flag1',
-        entity_id: 'someentity',
+        flagKey: 'flag1',
+        entityId: 'someentity',
         context: {
           fizz: 'buzz'
         }
       },
       {
-        flag_key: 'flag_boolean',
-        entity_id: 'someentity',
+        flagKey: 'flag_boolean',
+        entityId: 'someentity',
         context: {
           fizz: 'buzz'
         }
       },
       {
-        flag_key: 'notfound',
-        entity_id: 'someentity',
+        flagKey: 'notfound',
+        entityId: 'someentity',
         context: {
           fizz: 'buzz'
         }
@@ -112,33 +112,31 @@ describe('FliptEvaluationClient', () => {
     const variant = batch.responses[0];
 
     expect(variant?.type).toEqual('VARIANT_EVALUATION_RESPONSE_TYPE');
-    expect(variant?.variant_evaluation_response?.flag_key).toEqual('flag1');
-    expect(variant?.variant_evaluation_response?.match).toEqual(true);
-    expect(variant?.variant_evaluation_response?.reason).toEqual(
+    expect(variant?.variantEvaluationResponse?.flagKey).toEqual('flag1');
+    expect(variant?.variantEvaluationResponse?.match).toEqual(true);
+    expect(variant?.variantEvaluationResponse?.reason).toEqual(
       'MATCH_EVALUATION_REASON'
     );
-    expect(variant?.variant_evaluation_response?.segment_keys).toContain(
+    expect(variant?.variantEvaluationResponse?.segmentKeys).toContain(
       'segment1'
     );
-    expect(variant?.variant_evaluation_response?.variant_key).toContain(
+    expect(variant?.variantEvaluationResponse?.variantKey).toContain(
       'variant1'
     );
 
     const boolean = batch.responses[1];
     expect(boolean?.type).toEqual('BOOLEAN_EVALUATION_RESPONSE_TYPE');
-    expect(boolean?.boolean_evaluation_response?.flag_key).toEqual(
-      'flag_boolean'
-    );
-    expect(boolean?.boolean_evaluation_response?.enabled).toEqual(true);
-    expect(boolean?.boolean_evaluation_response?.reason).toEqual(
+    expect(boolean?.booleanEvaluationResponse?.flagKey).toEqual('flag_boolean');
+    expect(boolean?.booleanEvaluationResponse?.enabled).toEqual(true);
+    expect(boolean?.booleanEvaluationResponse?.reason).toEqual(
       'MATCH_EVALUATION_REASON'
     );
 
     const error = batch.responses[2];
     expect(error?.type).toEqual('ERROR_EVALUATION_RESPONSE_TYPE');
-    expect(error?.error_evaluation_response?.flag_key).toEqual('notfound');
-    expect(error?.error_evaluation_response?.namespace_key).toEqual('default');
-    expect(error?.error_evaluation_response?.reason).toEqual(
+    expect(error?.errorEvaluationResponse?.flagKey).toEqual('notfound');
+    expect(error?.errorEvaluationResponse?.namespaceKey).toEqual('default');
+    expect(error?.errorEvaluationResponse?.reason).toEqual(
       'NOT_FOUND_ERROR_EVALUATION_REASON'
     );
   });

--- a/flipt-client-browser/__tests__/evaluation.test.js
+++ b/flipt-client-browser/__tests__/evaluation.test.js
@@ -19,7 +19,7 @@ describe('FliptEvaluationClient', () => {
     }
   });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     client = await flipt.FliptEvaluationClient.init('default', {
       url: fliptUrl,
       authentication: {

--- a/flipt-client-browser/__tests__/evaluation.test.js
+++ b/flipt-client-browser/__tests__/evaluation.test.js
@@ -140,4 +140,10 @@ describe('FliptEvaluationClient', () => {
       'NOT_FOUND_ERROR_EVALUATION_REASON'
     );
   });
+
+  test('list flags', () => {
+    const flags = client.listFlags();
+    expect(flags).toBeDefined();
+    expect(flags.length).toBe(2);
+  });
 });

--- a/flipt-client-browser/package-lock.json
+++ b/flipt-client-browser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flipt-io/flipt-client-browser",
-  "version": "0.1.0",
+  "version": "0.2.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flipt-io/flipt-client-browser",
-      "version": "0.1.0",
+      "version": "0.2.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",

--- a/flipt-client-browser/package.json
+++ b/flipt-client-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipt-io/flipt-client-browser",
-  "version": "0.1.0",
+  "version": "0.2.0-rc.1",
   "description": "Flipt Client Evaluation Browser SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/flipt-client-browser/src/index.ts
+++ b/flipt-client-browser/src/index.ts
@@ -10,7 +10,9 @@ import {
   ErrorEvaluationResponse,
   EvaluationRequest,
   EvaluationResponse,
+  Flag,
   IFetcher,
+  ListFlagsResult,
   VariantEvaluationResponse,
   VariantResult
 } from './models.js';
@@ -268,5 +270,25 @@ export class FliptEvaluationClient {
       responses,
       requestDurationMillis
     };
+  }
+
+  public listFlags(): Flag[] {
+    const listFlagsResult: ListFlagsResult | null = this.engine.list_flags();
+
+    if (listFlagsResult === null) {
+      throw new Error('Failed to list flags');
+    }
+
+    const flags = deserialize<ListFlagsResult>(listFlagsResult);
+
+    if (flags.status === 'failure') {
+      throw new Error(flags.errorMessage);
+    }
+
+    if (!flags.result) {
+      throw new Error('Failed to list flags');
+    }
+
+    return flags.result.map(deserialize<Flag>);
   }
 }

--- a/flipt-client-browser/src/index.ts
+++ b/flipt-client-browser/src/index.ts
@@ -1,6 +1,6 @@
 import init, { Engine } from '../dist/flipt_engine_wasm.js';
 import wasm from '../dist/flipt_engine_wasm_bg.wasm';
-
+import { deserialize, serialize } from './utils';
 import {
   BatchEvaluationResponse,
   BatchResult,
@@ -127,60 +127,60 @@ export class FliptEvaluationClient {
 
   /**
    * Evaluate a variant flag
-   * @param flag_key - flag key to evaluate
-   * @param entity_id - entity id to evaluate
+   * @param flagKey - flag key to evaluate
+   * @param entityId - entity id to evaluate
    * @param context - optional evaluation context
    * @returns {VariantEvaluationResponse}
    */
   public evaluateVariant(
-    flag_key: string,
-    entity_id: string,
+    flagKey: string,
+    entityId: string,
     context: {}
   ): VariantEvaluationResponse {
-    const evaluation_request: EvaluationRequest = {
-      flag_key,
-      entity_id,
+    const evaluationRequest: EvaluationRequest = {
+      flagKey,
+      entityId,
       context
     };
 
-    const result = this.engine.evaluate_variant(
-      evaluation_request
-    ) as VariantResult;
+    const result = this.engine.evaluate_variant(serialize(evaluationRequest));
 
-    if (result.status === 'failure') {
-      throw new Error(result.error_message);
+    const variantResult = deserialize<VariantResult>(result);
+
+    if (variantResult.status === 'failure') {
+      throw new Error(result.errorMessage);
     }
 
-    return result.result as VariantEvaluationResponse;
+    return deserialize<VariantEvaluationResponse>(variantResult.result);
   }
 
   /**
    * Evaluate a boolean flag
-   * @param flag_key - flag key to evaluate
-   * @param entity_id - entity id to evaluate
+   * @param flagKey - flag key to evaluate
+   * @param entityId - entity id to evaluate
    * @param context - optional evaluation context
    * @returns {BooleanEvaluationResponse}
    */
   public evaluateBoolean(
-    flag_key: string,
-    entity_id: string,
+    flagKey: string,
+    entityId: string,
     context: {}
   ): BooleanEvaluationResponse {
-    const evaluation_request: EvaluationRequest = {
-      flag_key,
-      entity_id,
+    const evaluationRequest: EvaluationRequest = {
+      flagKey,
+      entityId,
       context
     };
 
-    const result = this.engine.evaluate_boolean(
-      evaluation_request
-    ) as BooleanResult;
+    const result = this.engine.evaluate_boolean(serialize(evaluationRequest));
 
-    if (result.status === 'failure') {
-      throw new Error(result.error_message);
+    const booleanResult = deserialize<BooleanResult>(result);
+
+    if (booleanResult.status === 'failure') {
+      throw new Error(booleanResult.errorMessage);
     }
 
-    return result.result as BooleanEvaluationResponse;
+    return deserialize<BooleanEvaluationResponse>(booleanResult.result);
   }
 
   /**
@@ -189,12 +189,14 @@ export class FliptEvaluationClient {
    * @returns {BatchEvaluationResponse}
    */
   public evaluateBatch(requests: EvaluationRequest[]): BatchEvaluationResponse {
-    const result = this.engine.evaluate_batch(requests) as BatchResult;
+    const result = this.engine.evaluate_batch(serialize(requests));
 
-    if (result.status === 'failure') {
-      throw new Error(result.error_message);
+    const batchResult = deserialize<BatchResult>(result);
+
+    if (batchResult.status === 'failure') {
+      throw new Error(batchResult.errorMessage);
     }
 
-    return result.result as BatchEvaluationResponse;
+    return deserialize<BatchEvaluationResponse>(batchResult.result);
   }
 }

--- a/flipt-client-browser/src/models.ts
+++ b/flipt-client-browser/src/models.ts
@@ -9,11 +9,11 @@ export interface IFetcher {
 export interface AuthenticationStrategy {}
 
 export interface ClientTokenAuthentication extends AuthenticationStrategy {
-  client_token: string;
+  clientToken: string;
 }
 
 export interface JWTAuthentication extends AuthenticationStrategy {
-  jwt_token: string;
+  jwtToken: string;
 }
 
 export interface ClientOptions {
@@ -24,52 +24,52 @@ export interface ClientOptions {
 }
 
 export interface EvaluationRequest {
-  flag_key: string;
-  entity_id: string;
+  flagKey: string;
+  entityId: string;
   context: object;
 }
 
 export interface VariantEvaluationResponse {
   match: boolean;
-  segment_keys: string[];
+  segmentKeys: string[];
   reason: string;
-  flag_key: string;
-  variant_key?: string;
-  variant_attachment?: string;
-  request_duration_millis: number;
+  flagKey: string;
+  variantKey?: string;
+  variantAttachment?: string;
+  requestDurationMillis: number;
   timestamp: string;
 }
 
 export interface BooleanEvaluationResponse {
   enabled: boolean;
-  flag_key: string;
+  flagKey: string;
   reason: string;
-  request_duration_millis: number;
+  requestDurationMillis: number;
   timestamp: string;
 }
 
 export interface ErrorEvaluationResponse {
-  flag_key: string;
-  namespace_key: string;
+  flagKey: string;
+  namespaceKey: string;
   reason: string;
 }
 
 export interface EvaluationResponse {
   type: string;
-  boolean_evaluation_response?: BooleanEvaluationResponse;
-  variant_evaluation_response?: VariantEvaluationResponse;
-  error_evaluation_response?: ErrorEvaluationResponse;
+  booleanEvaluationResponse?: BooleanEvaluationResponse;
+  variantEvaluationResponse?: VariantEvaluationResponse;
+  errorEvaluationResponse?: ErrorEvaluationResponse;
 }
 
 export interface BatchEvaluationResponse {
   responses: EvaluationResponse[];
-  request_duration_millis: number;
+  requestDurationMillis: number;
 }
 
 export interface Result<T> {
   status: 'success' | 'failure';
   result?: T;
-  error_message: string;
+  errorMessage: string;
 }
 
 export interface VariantResult extends Result<VariantEvaluationResponse> {}

--- a/flipt-client-browser/src/models.ts
+++ b/flipt-client-browser/src/models.ts
@@ -1,79 +1,226 @@
+/**
+ * Represents the options for a fetcher function.
+ */
 export interface IFetcherOptions {
+  /**
+   * ETag for the request.
+   */
   etag?: string;
 }
 
+/**
+ * Represents a function that fetches a response from a remote Flipt instance.
+ */
 export interface IFetcher {
   (opts?: IFetcherOptions): Promise<Response>;
 }
 
+/**
+ * Authentication strategy for the client.
+ */
 export interface AuthenticationStrategy {}
 
+/**
+ * Client Token Authentication.
+ * @see {@link https://docs.flipt.io/authentication/using-tokens}.
+ */
 export interface ClientTokenAuthentication extends AuthenticationStrategy {
+  /**
+   * Flipt client token.
+   */
   clientToken: string;
 }
 
+/**
+ * JWT Authentication.
+ * @see {@link https://docs.flipt.io/authentication/using-jwts}
+ */
 export interface JWTAuthentication extends AuthenticationStrategy {
+  /**
+   * JWT token.
+   */
   jwtToken: string;
 }
 
 export interface ClientOptions {
+  /**
+   * The URL of the upstream Flipt instance.
+   *
+   * @defaultValue `http://localhost:8080`
+   */
   url?: string;
+  /**
+   * The interval (seconds) in which to fetch new flag state.
+   * @defaultValue `120` seconds.
+   */
+  updateInterval?: number;
+  /**
+   * The authentication strategy to use when communicating with the upstream Flipt instance. If not provided, the client will default to no authentication.
+   *
+   * @remarks
+   * Client supports the following authentication strategies: No Authentication, {@link ClientTokenAuthentication} and {@link JWTAuthentication}.
+   */
   authentication?: AuthenticationStrategy;
+  /**
+   * The reference to use when fetching flag state. If not provided, reference will not be used.
+   * @see {@link https://docs.flipt.io/guides/user/using-references}
+   */
   reference?: string;
   fetcher?: IFetcher;
 }
 
+/**
+ * Represents a request to evaluate a feature flag.
+ */
 export interface EvaluationRequest {
+  /**
+   * Feature flag key
+   */
   flagKey: string;
+  /**
+   * Entity identifier
+   */
   entityId: string;
+  /**
+   * Context information for flag evaluation
+   *
+   * @example
+   * ```
+   * {
+   *  fizz: 'buzz',
+   *  kind: 'small'
+   * }
+   * ```
+   */
   context: object;
 }
 
-export interface VariantEvaluationResponse {
-  match: boolean;
-  segmentKeys: string[];
-  reason: string;
-  flagKey: string;
-  variantKey?: string;
-  variantAttachment?: string;
-  requestDurationMillis: number;
-  timestamp: string;
-}
-
-export interface BooleanEvaluationResponse {
+/**
+ * Represents a feature flag in the system.
+ */
+export interface Flag {
+  /**
+   * Unique key for the flag.
+   */
+  key: string;
+  /**
+   * Status of the flag. For a Variant flag, this represents whether
+   * the flag is enabled. For a Boolean flag, this represents the
+   * default value.
+   */
   enabled: boolean;
-  flagKey: string;
+  /**
+   * Type of the feature flag. This can be either 'BOOLEAN_FLAG_TYPE' or 'VARIANT_FLAG_TYPE'.
+   */
+  type: string;
+}
+
+/**
+ * Represents the response returned after evaluating a feature flag variant.
+ */
+export interface VariantEvaluationResponse {
+  /** Indicates whether the feature flag evaluation resulted in a match. */
+  match: boolean;
+  /** List of segment keys that were used to determine the match. */
+  segmentKeys: string[];
+  /** Reason for the result that occurred during the evaluation. */
   reason: string;
+  /** Key of the feature flag that was being evaluated. */
+  flagKey: string;
+  /** Variant key that was returned if the evaluation resulted in a match. */
+  variantKey: string;
+  /** Additional data attached to the variant if the evaluation resulted in a match. */
+  variantAttachment: string;
+  /** Duration of the request in milliseconds. */
   requestDurationMillis: number;
+  /** Timestamp when the response was generated. */
   timestamp: string;
 }
 
-export interface ErrorEvaluationResponse {
+/**
+ * Represents the response returned after evaluating a feature flag.
+ */
+export interface BooleanEvaluationResponse {
+  /** Evaluation value of the flag. */
+  enabled: boolean;
+  /** Key of the feature flag that was being evaluated. */
   flagKey: string;
+  /** Reason for the result that occurred during the evaluation. */
+  reason: string;
+  /** Duration of the request in milliseconds. */
+  requestDurationMillis: number;
+  /** Timestamp when the response was generated. */
+  timestamp: string;
+}
+
+/**
+ * Represents the response returned when an error occurs during the evaluation of a feature flag.
+ */
+export interface ErrorEvaluationResponse {
+  /** Key of the feature flag that was being evaluated. */
+  flagKey: string;
+  /** Key of the namespace in which the feature flag resides. */
   namespaceKey: string;
+  /** Reason for the result that occurred during the evaluation. */
   reason: string;
 }
 
+/**
+ * Represents a response object that encapsulates various types of evaluation results.
+ */
 export interface EvaluationResponse {
+  /**
+   * The type of evaluation response. Possible values include 'VARIANT_EVALUATION_RESPONSE_TYPE',
+   * 'BOOLEAN_EVALUATION_RESPONSE_TYPE', or 'ERROR_EVALUATION_RESPONSE_TYPE'.
+   */
   type: string;
+  /** Boolean evaluation response base on the type */
   booleanEvaluationResponse?: BooleanEvaluationResponse;
+  /** Variant evaluation response base on the type */
   variantEvaluationResponse?: VariantEvaluationResponse;
+  /** Error evaluation response base on the type*/
   errorEvaluationResponse?: ErrorEvaluationResponse;
 }
 
+/**
+ * Represents the response returned after batch evaluating multiple feature flags.
+ */
 export interface BatchEvaluationResponse {
+  /** Array containing individual evaluation responses for each feature flag. */
   responses: EvaluationResponse[];
+  /** Duration of the request in milliseconds. */
   requestDurationMillis: number;
 }
 
-export interface Result<T> {
-  status: 'success' | 'failure';
-  result?: T;
-  errorMessage: string;
-}
-
+/**
+ * Represents a specialized result object for variant evaluation, extending
+ * the generic Result interface with a specific type VariantEvaluationResponse.
+ */
 export interface VariantResult extends Result<VariantEvaluationResponse> {}
 
+/**
+ * Represents a specialized result object for boolean evaluation, extending
+ * the generic Result interface with a specific type BooleanEvaluationResponse.
+ */
 export interface BooleanResult extends Result<BooleanEvaluationResponse> {}
 
+/**
+ * Represents a specialized result object for batch evaluation, extending
+ * the generic Result interface with a specific type BatchEvaluationResponse.
+ */
 export interface BatchResult extends Result<BatchEvaluationResponse> {}
+
+/**
+ * Represents a specialized result object for listing flags, extending
+ * the generic Result interface with a specific type ListFlagsResponse.
+ */
+export interface ListFlagsResult extends Result<Flag[]> {}
+
+export interface Result<T> {
+  /** Status of the result - `success` or `failure`. */
+  status: string;
+  /** Actual result of type T if the operation was successful. */
+  result?: T;
+  /** Error message describing the reason for failure, if applicable.*/
+  errorMessage: string;
+}

--- a/flipt-client-browser/src/utils.ts
+++ b/flipt-client-browser/src/utils.ts
@@ -1,0 +1,31 @@
+export function snakeToCamel(str: string): string {
+  return str.replace(/([-_][a-z])/g, (group) =>
+    group.toUpperCase().replace('-', '').replace('_', '')
+  );
+}
+
+export function camelToSnake(str: string): string {
+  return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}
+
+export function deserialize<T>(data: any): T {
+  const result: any = {};
+  for (const key in data) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
+      const camelKey = snakeToCamel(key);
+      result[camelKey] = data[key];
+    }
+  }
+  return result as T;
+}
+
+export function serialize<T>(data: T): any {
+  const result: any = {};
+  for (const key in data) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
+      const snakeKey = camelToSnake(key);
+      result[snakeKey] = (data as any)[key];
+    }
+  }
+  return result;
+}

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -29,6 +29,12 @@ export class FliptEvaluationClient {
     this.fetcher = fetcher;
   }
 
+  /**
+   * Initialize the client
+   * @param namespace - optional namespace to evaluate flags
+   * @param options - optional client options
+   * @returns {Promise<FliptEvaluationClient>}
+   */
   static async init(
     namespace: string = 'default',
     options: ClientOptions<AuthenticationStrategy> = {
@@ -120,6 +126,10 @@ export class FliptEvaluationClient {
     }
   }
 
+  /**
+   * Refresh the flags snapshot
+   * @returns void
+   */
   public async refresh() {
     const opts = { etag: this.etag };
     const resp = await this.fetcher(opts);
@@ -136,6 +146,13 @@ export class FliptEvaluationClient {
     this.engine.snapshot(data);
   }
 
+  /**
+   * Evaluate a variant flag
+   * @param flagKey - flag key to evaluate
+   * @param entityId - entity id to evaluate
+   * @param context - optional evaluation context
+   * @returns {VariantEvaluationResponse}
+   */
   public evaluateVariant(
     flagKey: string,
     entityId: string,
@@ -168,6 +185,13 @@ export class FliptEvaluationClient {
     return deserialize<VariantEvaluationResponse>(variantResult.result);
   }
 
+  /**
+   * Evaluate a boolean flag
+   * @param flagKey - flag key to evaluate
+   * @param entityId - entity id to evaluate
+   * @param context - optional evaluation context
+   * @returns {BooleanEvaluationResponse}
+   */
   public evaluateBoolean(
     flagKey: string,
     entityId: string,
@@ -200,6 +224,11 @@ export class FliptEvaluationClient {
     return deserialize<BooleanEvaluationResponse>(booleanResult.result);
   }
 
+  /**
+   * Evaluate a batch of flag requests
+   * @param requests evaluation requests
+   * @returns {BatchEvaluationResponse}
+   */
   public evaluateBatch(requests: EvaluationRequest[]): BatchEvaluationResponse {
     const serializedRequests = requests.map(serialize);
     const batchResult: BatchResult | null =

--- a/test/main.go
+++ b/test/main.go
@@ -154,7 +154,6 @@ func getFFITestContainer(_ context.Context, client *dagger.Client, hostDirectory
 		}).
 		WithDirectory("/src/flipt-evaluation", hostDirectory.Directory("flipt-evaluation")).
 		WithFile("/src/Cargo.toml", hostDirectory.File("Cargo.toml")).
-		WithWorkdir("/src").
 		WithExec([]string{"cargo", "build", "-p", "flipt-engine-ffi", "--release"}) // Build the dynamic library
 }
 
@@ -185,9 +184,9 @@ func getWasmTestContainer(_ context.Context, client *dagger.Client, hostDirector
 func pythonTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("python").Container().From("python:3.11-bookworm").
 		WithExec([]string{"pip", "install", "poetry==1.7.0"}).
+		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-python")).
 		WithFile(fmt.Sprintf("/src/ext/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
-		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -203,10 +202,10 @@ func goTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("go").Container().From("golang:1.21.3-bookworm").
 		WithExec([]string{"apt-get", "update"}).
 		WithExec([]string{"apt-get", "-y", "install", "build-essential"}).
-		WithFile(fmt.Sprintf("/src/ext/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
-		WithFile("/src/ext/flipt_engine.h", t.test.File(headerFile)).
 		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-go")).
+		WithFile(fmt.Sprintf("/src/ext/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
+		WithFile("/src/ext/flipt_engine.h", t.test.File(headerFile)).
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -245,9 +244,9 @@ func nodeTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 // rubyTests runs the ruby integration test suite against a container running Flipt.
 func rubyTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("ruby").Container().From("ruby:3.1-bookworm").
+		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-ruby")).
 		WithFile(fmt.Sprintf("/src/lib/ext/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
-		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -305,11 +304,11 @@ func browserTests(ctx context.Context, client *dagger.Client, t *testCase) error
 // dartTests runs the dart integration test suite against a container running Flipt.
 func dartTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("dart").Container().From("dart:stable").
+		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-dart"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".gitignore", ".dart_tool/"},
 		}).
 		WithFile(fmt.Sprintf("/src/lib/src/ffi/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
-		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").

--- a/test/main.go
+++ b/test/main.go
@@ -223,13 +223,13 @@ func goTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 // nodeTests runs the node integration test suite against a container running Flipt.
 func nodeTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("node").Container().From("node:21.2-bookworm").
+		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-node"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".node_modules/", ".gitignore", "dist/"},
 		}).
 		WithDirectory("/src/dist", t.test.Directory(wasmDir), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".node_modules/", ".gitignore", "package.json", "README.md", "LICENSE"},
 		}).
-		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -283,13 +283,13 @@ func javaTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 // browserTests runs the browser integration test suite against a container running Flipt.
 func browserTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("browser").Container().From("node:21.2-bookworm").
+		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-browser"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".node_modules/", ".gitignore", "dist/"},
 		}).
 		WithDirectory("/src/dist", t.test.Directory(wasmDir), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".node_modules/", ".gitignore", "package.json", "README.md", "LICENSE"},
 		}).
-		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").

--- a/test/main.go
+++ b/test/main.go
@@ -154,6 +154,7 @@ func getFFITestContainer(_ context.Context, client *dagger.Client, hostDirectory
 		}).
 		WithDirectory("/src/flipt-evaluation", hostDirectory.Directory("flipt-evaluation")).
 		WithFile("/src/Cargo.toml", hostDirectory.File("Cargo.toml")).
+		WithWorkdir("/src").
 		WithExec([]string{"cargo", "build", "-p", "flipt-engine-ffi", "--release"}) // Build the dynamic library
 }
 
@@ -184,9 +185,9 @@ func getWasmTestContainer(_ context.Context, client *dagger.Client, hostDirector
 func pythonTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("python").Container().From("python:3.11-bookworm").
 		WithExec([]string{"pip", "install", "poetry==1.7.0"}).
-		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-python")).
 		WithFile(fmt.Sprintf("/src/ext/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
+		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -202,10 +203,10 @@ func goTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("go").Container().From("golang:1.21.3-bookworm").
 		WithExec([]string{"apt-get", "update"}).
 		WithExec([]string{"apt-get", "-y", "install", "build-essential"}).
-		WithWorkdir("/src").
-		WithDirectory("/src", t.dir.Directory("flipt-client-go")).
 		WithFile(fmt.Sprintf("/src/ext/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
 		WithFile("/src/ext/flipt_engine.h", t.test.File(headerFile)).
+		WithWorkdir("/src").
+		WithDirectory("/src", t.dir.Directory("flipt-client-go")).
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -244,9 +245,9 @@ func nodeTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 // rubyTests runs the ruby integration test suite against a container running Flipt.
 func rubyTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("ruby").Container().From("ruby:3.1-bookworm").
-		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-ruby")).
 		WithFile(fmt.Sprintf("/src/lib/ext/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
+		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -266,11 +267,11 @@ func javaTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	}
 
 	_, err := client.Pipeline("java").Container().From("gradle:8.5.0-jdk11").
-		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-java"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{"./.idea/", ".gradle/", "build/"},
 		}).
 		WithFile(fmt.Sprintf("/src/src/main/resources/linux-%s/libfliptengine.so", path), t.test.File(libFile)).
+		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -304,11 +305,11 @@ func browserTests(ctx context.Context, client *dagger.Client, t *testCase) error
 // dartTests runs the dart integration test suite against a container running Flipt.
 func dartTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	_, err := client.Pipeline("dart").Container().From("dart:stable").
-		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-dart"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".gitignore", ".dart_tool/"},
 		}).
 		WithFile(fmt.Sprintf("/src/lib/src/ffi/linux_%s/libfliptengine.so", architecture), t.test.File(libFile)).
+		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").

--- a/test/main.go
+++ b/test/main.go
@@ -266,11 +266,11 @@ func javaTests(ctx context.Context, client *dagger.Client, t *testCase) error {
 	}
 
 	_, err := client.Pipeline("java").Container().From("gradle:8.5.0-jdk11").
+		WithWorkdir("/src").
 		WithDirectory("/src", t.dir.Directory("flipt-client-java"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{"./.idea/", ".gradle/", "build/"},
 		}).
 		WithFile(fmt.Sprintf("/src/src/main/resources/linux-%s/libfliptengine.so", path), t.test.File(libFile)).
-		WithWorkdir("/src").
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").


### PR DESCRIPTION
- redoes browser client to use similar camel casing for field/argument names like in #373 
- adds list flags method to browser SDK

## TODO

- [ ] share code between node and browser SDKs to remove duplication