### PR TITLE
fix(node/browser): export models outside package

### DIFF
--- a/flipt-client-browser/package-lock.json
+++ b/flipt-client-browser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flipt-io/flipt-client-browser",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flipt-io/flipt-client-browser",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",

--- a/flipt-client-browser/package.json
+++ b/flipt-client-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipt-io/flipt-client-browser",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Flipt Client Evaluation Browser SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/flipt-client-browser/src/index.ts
+++ b/flipt-client-browser/src/index.ts
@@ -3,19 +3,17 @@ import wasm from '../dist/flipt_engine_wasm_bg.wasm';
 import { deserialize, serialize } from './utils';
 import {
   BatchEvaluationResponse,
-  BatchResult,
   BooleanEvaluationResponse,
-  BooleanResult,
   ClientOptions,
   ErrorEvaluationResponse,
   EvaluationRequest,
   EvaluationResponse,
   Flag,
   IFetcher,
-  ListFlagsResult,
   VariantEvaluationResponse,
-  VariantResult
-} from './models.js';
+} from './models';
+
+import { VariantResult, BooleanResult, BatchResult, ListFlagsResult } from './internal/models';
 
 export class FliptEvaluationClient {
   private engine: Engine;

--- a/flipt-client-browser/src/index.ts
+++ b/flipt-client-browser/src/index.ts
@@ -292,3 +292,5 @@ export class FliptEvaluationClient {
     return flags.result.map(deserialize<Flag>);
   }
 }
+
+export * from './models';

--- a/flipt-client-browser/src/index.ts
+++ b/flipt-client-browser/src/index.ts
@@ -10,10 +10,15 @@ import {
   EvaluationResponse,
   Flag,
   IFetcher,
-  VariantEvaluationResponse,
+  VariantEvaluationResponse
 } from './models';
 
-import { VariantResult, BooleanResult, BatchResult, ListFlagsResult } from './internal/models';
+import {
+  VariantResult,
+  BooleanResult,
+  BatchResult,
+  ListFlagsResult
+} from './internal/models';
 
 export class FliptEvaluationClient {
   private engine: Engine;

--- a/flipt-client-browser/src/internal/models.ts
+++ b/flipt-client-browser/src/internal/models.ts
@@ -1,4 +1,9 @@
-import { BatchEvaluationResponse, BooleanEvaluationResponse, Flag, VariantEvaluationResponse } from "../models";
+import {
+  BatchEvaluationResponse,
+  BooleanEvaluationResponse,
+  Flag,
+  VariantEvaluationResponse
+} from '../models';
 
 /**
  * Represents a specialized result object for variant evaluation, extending

--- a/flipt-client-browser/src/internal/models.ts
+++ b/flipt-client-browser/src/internal/models.ts
@@ -1,0 +1,34 @@
+import { BatchEvaluationResponse, BooleanEvaluationResponse, Flag, VariantEvaluationResponse } from "../models";
+
+/**
+ * Represents a specialized result object for variant evaluation, extending
+ * the generic Result interface with a specific type VariantEvaluationResponse.
+ */
+export interface VariantResult extends Result<VariantEvaluationResponse> {}
+
+/**
+ * Represents a specialized result object for boolean evaluation, extending
+ * the generic Result interface with a specific type BooleanEvaluationResponse.
+ */
+export interface BooleanResult extends Result<BooleanEvaluationResponse> {}
+
+/**
+ * Represents a specialized result object for batch evaluation, extending
+ * the generic Result interface with a specific type BatchEvaluationResponse.
+ */
+export interface BatchResult extends Result<BatchEvaluationResponse> {}
+
+/**
+ * Represents a specialized result object for listing flags, extending
+ * the generic Result interface with a specific type ListFlagsResponse.
+ */
+export interface ListFlagsResult extends Result<Flag[]> {}
+
+export interface Result<T> {
+  /** Status of the result - `success` or `failure`. */
+  status: string;
+  /** Actual result of type T if the operation was successful. */
+  result?: T;
+  /** Error message describing the reason for failure, if applicable.*/
+  errorMessage: string;
+}

--- a/flipt-client-browser/src/models.ts
+++ b/flipt-client-browser/src/models.ts
@@ -191,4 +191,3 @@ export interface BatchEvaluationResponse {
   /** Duration of the request in milliseconds. */
   requestDurationMillis: number;
 }
-

--- a/flipt-client-browser/src/models.ts
+++ b/flipt-client-browser/src/models.ts
@@ -192,35 +192,3 @@ export interface BatchEvaluationResponse {
   requestDurationMillis: number;
 }
 
-/**
- * Represents a specialized result object for variant evaluation, extending
- * the generic Result interface with a specific type VariantEvaluationResponse.
- */
-export interface VariantResult extends Result<VariantEvaluationResponse> {}
-
-/**
- * Represents a specialized result object for boolean evaluation, extending
- * the generic Result interface with a specific type BooleanEvaluationResponse.
- */
-export interface BooleanResult extends Result<BooleanEvaluationResponse> {}
-
-/**
- * Represents a specialized result object for batch evaluation, extending
- * the generic Result interface with a specific type BatchEvaluationResponse.
- */
-export interface BatchResult extends Result<BatchEvaluationResponse> {}
-
-/**
- * Represents a specialized result object for listing flags, extending
- * the generic Result interface with a specific type ListFlagsResponse.
- */
-export interface ListFlagsResult extends Result<Flag[]> {}
-
-export interface Result<T> {
-  /** Status of the result - `success` or `failure`. */
-  status: string;
-  /** Actual result of type T if the operation was successful. */
-  result?: T;
-  /** Error message describing the reason for failure, if applicable.*/
-  errorMessage: string;
-}

--- a/flipt-client-node/package-lock.json
+++ b/flipt-client-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flipt-io/flipt-client",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flipt-io/flipt-client",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.10",

--- a/flipt-client-node/package.json
+++ b/flipt-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipt-io/flipt-client",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Flipt Client Evaluation SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -1,3 +1,5 @@
+
+
 import { Engine } from '../dist/flipt_engine_wasm.js';
 import { serialize, deserialize } from './utils';
 
@@ -316,3 +318,5 @@ export class FliptEvaluationClient {
     this.stopAutoRefresh();
   }
 }
+
+export * from './models';

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -3,20 +3,18 @@ import { serialize, deserialize } from './utils';
 
 import {
   AuthenticationStrategy,
-  BooleanResult,
-  BatchResult,
   ClientOptions,
   EvaluationRequest,
   IFetcher,
-  VariantResult,
   VariantEvaluationResponse,
   BooleanEvaluationResponse,
   BatchEvaluationResponse,
   ErrorEvaluationResponse,
   EvaluationResponse,
   Flag,
-  ListFlagsResult
 } from './models';
+
+import { VariantResult, BooleanResult, BatchResult, ListFlagsResult } from './internal/models';
 
 export class FliptEvaluationClient {
   private engine: Engine;

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -11,10 +11,15 @@ import {
   BatchEvaluationResponse,
   ErrorEvaluationResponse,
   EvaluationResponse,
-  Flag,
+  Flag
 } from './models';
 
-import { VariantResult, BooleanResult, BatchResult, ListFlagsResult } from './internal/models';
+import {
+  VariantResult,
+  BooleanResult,
+  BatchResult,
+  ListFlagsResult
+} from './internal/models';
 
 export class FliptEvaluationClient {
   private engine: Engine;

--- a/flipt-client-node/src/index.ts
+++ b/flipt-client-node/src/index.ts
@@ -1,5 +1,3 @@
-
-
 import { Engine } from '../dist/flipt_engine_wasm.js';
 import { serialize, deserialize } from './utils';
 

--- a/flipt-client-node/src/internal/models.ts
+++ b/flipt-client-node/src/internal/models.ts
@@ -1,4 +1,9 @@
-import {Flag, VariantEvaluationResponse, BooleanEvaluationResponse, BatchEvaluationResponse } from "../models";
+import {
+  Flag,
+  VariantEvaluationResponse,
+  BooleanEvaluationResponse,
+  BatchEvaluationResponse
+} from '../models';
 /**
  * Represents a specialized result object for variant evaluation, extending
  * the generic Result interface with a specific type VariantEvaluationResponse.

--- a/flipt-client-node/src/internal/models.ts
+++ b/flipt-client-node/src/internal/models.ts
@@ -1,0 +1,33 @@
+import {Flag, VariantEvaluationResponse, BooleanEvaluationResponse, BatchEvaluationResponse } from "../models";
+/**
+ * Represents a specialized result object for variant evaluation, extending
+ * the generic Result interface with a specific type VariantEvaluationResponse.
+ */
+export interface VariantResult extends Result<VariantEvaluationResponse> {}
+
+/**
+ * Represents a specialized result object for boolean evaluation, extending
+ * the generic Result interface with a specific type BooleanEvaluationResponse.
+ */
+export interface BooleanResult extends Result<BooleanEvaluationResponse> {}
+
+/**
+ * Represents a specialized result object for batch evaluation, extending
+ * the generic Result interface with a specific type BatchEvaluationResponse.
+ */
+export interface BatchResult extends Result<BatchEvaluationResponse> {}
+
+/**
+ * Represents a specialized result object for listing flags, extending
+ * the generic Result interface with a specific type ListFlagsResponse.
+ */
+export interface ListFlagsResult extends Result<Flag[]> {}
+
+export interface Result<T> {
+  /** Status of the result - `success` or `failure`. */
+  status: string;
+  /** Actual result of type T if the operation was successful. */
+  result?: T;
+  /** Error message describing the reason for failure, if applicable.*/
+  errorMessage: string;
+}

--- a/flipt-client-node/src/models.ts
+++ b/flipt-client-node/src/models.ts
@@ -191,4 +191,3 @@ export interface BatchEvaluationResponse {
   /** Duration of the request in milliseconds. */
   requestDurationMillis: number;
 }
-

--- a/flipt-client-node/src/models.ts
+++ b/flipt-client-node/src/models.ts
@@ -192,35 +192,3 @@ export interface BatchEvaluationResponse {
   requestDurationMillis: number;
 }
 
-/**
- * Represents a specialized result object for variant evaluation, extending
- * the generic Result interface with a specific type VariantEvaluationResponse.
- */
-export interface VariantResult extends Result<VariantEvaluationResponse> {}
-
-/**
- * Represents a specialized result object for boolean evaluation, extending
- * the generic Result interface with a specific type BooleanEvaluationResponse.
- */
-export interface BooleanResult extends Result<BooleanEvaluationResponse> {}
-
-/**
- * Represents a specialized result object for batch evaluation, extending
- * the generic Result interface with a specific type BatchEvaluationResponse.
- */
-export interface BatchResult extends Result<BatchEvaluationResponse> {}
-
-/**
- * Represents a specialized result object for listing flags, extending
- * the generic Result interface with a specific type ListFlagsResponse.
- */
-export interface ListFlagsResult extends Result<Flag[]> {}
-
-export interface Result<T> {
-  /** Status of the result - `success` or `failure`. */
-  status: string;
-  /** Actual result of type T if the operation was successful. */
-  result?: T;
-  /** Error message describing the reason for failure, if applicable.*/
-  errorMessage: string;
-}


### PR DESCRIPTION
I was working on a react wrapper SDK and realized that we don't export any of our models outside the main module.

This change re-exports those types so they can be used externally

![CleanShot 2024-09-20 at 16 03 10](https://github.com/user-attachments/assets/4b46bbcb-ac39-4cfe-b16f-f7f4eb60f357)
