### PR TITLE
fix(browser): use another way for etag checking

### DIFF
--- a/flipt-client-browser/package.json
+++ b/flipt-client-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipt-io/flipt-client-browser",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Flipt Client Evaluation Browser SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/flipt-client-browser/src/index.ts
+++ b/flipt-client-browser/src/index.ts
@@ -85,10 +85,6 @@ export class FliptEvaluationClient {
           headers
         });
 
-        if (resp.status === 304) {
-          return resp;
-        }
-
         if (!resp.ok) {
           throw new Error(`Failed to fetch data: ${resp.statusText}`);
         }
@@ -99,7 +95,7 @@ export class FliptEvaluationClient {
 
     // handle case if they pass in a custom fetcher that doesn't throw on non-2xx status codes
     const resp = await fetcher();
-    if (!resp.ok && resp.status !== 304) {
+    if (!resp.ok) {
       throw new Error(`Failed to fetch data: ${resp.statusText}`);
     }
 
@@ -129,10 +125,12 @@ export class FliptEvaluationClient {
     const opts = { etag: this.etag };
     const resp = await this.fetcher(opts);
 
-    if (resp.status === 304) {
-      this.storeEtag(resp);
+    let etag = resp.headers.get('etag');
+    if (this.etag && this.etag === etag) {
       return false;
     }
+
+    this.storeEtag(resp);
 
     const data = await resp.json();
     this.engine.snapshot(data);

--- a/flipt-client-browser/src/index.ts
+++ b/flipt-client-browser/src/index.ts
@@ -85,7 +85,7 @@ export class FliptEvaluationClient {
           headers
         });
 
-        if (!resp.ok) {
+        if (!resp.ok && resp.status !== 304) {
           throw new Error(`Failed to fetch data: ${resp.statusText}`);
         }
 


### PR DESCRIPTION
It turns out that fetch API will got the HTTP 200 in browser even when server response will be HTTP 304.

https://stackoverflow.com/questions/62378379/do-the-fetch-api-and-axios-see-304-responses-as-200
