### PR TITLE
chore: Rc release windows java

### DIFF
--- a/flipt-client-java/build.gradle
+++ b/flipt-client-java/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'io.flipt'
-version = '0.9.0'
+version = '0.10.0-rc.1'
 description = 'Flipt Client SDK'
 
 java {

--- a/flipt-client-java/build.musl.gradle
+++ b/flipt-client-java/build.musl.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'io.flipt'
-version = '0.1.0'
+version = '0.2.0-rc.1'
 description = 'Flipt Client SDK'
 
 java {

--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-engine-ffi"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"


### PR DESCRIPTION
need to trigger a release of the engine so we can get the windows packaging working