### PR TITLE
chore(deps-dev): bump rubocop to 1.68 in flipt-client-ruby

### DIFF
--- a/flipt-client-ruby/Gemfile
+++ b/flipt-client-ruby/Gemfile
@@ -5,11 +5,11 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in flipt-client-ruby.gemspec
 gemspec
 
-gem 'ffi', '~> 1.16'
+gem 'ffi', '~> 1.17'
 gem 'rake', '~> 12.0'
 
 group :development do
   gem 'bundler', '~> 2.0'
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', require: false
+  gem 'rubocop', '~> 1.68', require: false
 end

--- a/flipt-client-ruby/Gemfile.lock
+++ b/flipt-client-ruby/Gemfile.lock
@@ -1,25 +1,24 @@
 PATH
   remote: .
   specs:
-    flipt_client (0.10.0)
+    flipt_client (0.12.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
-    ffi (1.16.3)
-    json (2.7.0)
+    ffi (1.17.0)
+    json (2.7.5)
     language_server-protocol (3.17.0.3)
-    parallel (1.23.0)
-    parser (3.2.2.4)
+    parallel (1.26.3)
+    parser (3.3.5.1)
       ast (~> 2.4.1)
       racc
-    racc (1.7.3)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (12.3.3)
-    regexp_parser (2.8.2)
-    rexml (3.2.6)
+    regexp_parser (2.9.2)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -33,32 +32,31 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.58.0)
+    rubocop (1.68.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
+    rubocop-ast (1.33.1)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 2.0)
-  ffi (~> 1.16)
+  ffi (~> 1.17)
   flipt_client!
   rake (~> 12.0)
   rspec (~> 3.0)
-  rubocop
+  rubocop (~> 1.68)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
The older version depends on rexml which has few issues.
