### PR TITLE
build: go and java packaging now default to glibc

### DIFF
--- a/package/ffi/main.go
+++ b/package/ffi/main.go
@@ -23,10 +23,10 @@ var (
 	engineTag string
 	sdksToFn  = map[string]sdks.SDK{
 		"python":    &sdks.PythonSDK{},
-		"go":        &sdks.GoSDK{},
+		"go":        &sdks.GoSDK{Libc: platform.Glibc},
 		"go-musl":   &sdks.GoSDK{Libc: platform.Musl},
 		"ruby":      &sdks.RubySDK{},
-		"java":      &sdks.JavaSDK{},
+		"java":      &sdks.JavaSDK{Libc: platform.Glibc},
 		"java-musl": &sdks.JavaSDK{Libc: platform.Musl},
 		"dart":      &sdks.DartSDK{},
 		"csharp":    &sdks.CSharpSDK{},


### PR DESCRIPTION
Should fix what I was seeing in https://github.com/flipt-io/flipt-client-sdks/pull/559#issuecomment-2523843142

The problem was that there was no libc set for Go (nor Java), so this line:

https://github.com/flipt-io/flipt-client-sdks/blob/ab2e0d52574c46c67b96f4a99a43129dcabedc3c/package/ffi/sdks/go.go#L66

Would evaluate as:

```
WithDirectory("/tmp/ext", hostDirectory.Directory("tmp/))
```
