### PR TITLE
chore: forgot to update versions after release

### DIFF
--- a/flipt-client-java/build.gradle
+++ b/flipt-client-java/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'io.flipt'
-version = '0.11.0'
+version = '0.12.0'
 description = 'Flipt Client SDK'
 
 java {

--- a/flipt-client-java/build.musl.gradle
+++ b/flipt-client-java/build.musl.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'io.flipt'
-version = '0.3.0'
+version = '0.4.0'
 description = 'Flipt Client SDK'
 
 java {

--- a/flipt-client-node/package-lock.json
+++ b/flipt-client-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flipt-io/flipt-client",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flipt-io/flipt-client",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.10",

--- a/flipt-client-node/package.json
+++ b/flipt-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipt-io/flipt-client",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Flipt Client Evaluation SDK for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/release/sdks/base.py
+++ b/release/sdks/base.py
@@ -15,8 +15,7 @@ class SDK(ABC):
     def update_version(self, new_version: str):
         pass
 
-    def tag_and_push(self, new_version: str):
-        tag = f"{self.name}-v{new_version}"
+    def _create_and_push_tag(self, tag: str):
         try:
             subprocess.run(["git", "checkout", "-b", f"release/{tag}"], check=True)
             subprocess.run(["git", "commit", "-a", "--allow-empty", "-m", f"Release {tag}"], check=True)
@@ -27,6 +26,10 @@ class SDK(ABC):
             print(f"Created and pushed tag: {tag}")
         except subprocess.CalledProcessError as e:
             print(f"Error during git operations: {e}")
+
+    def tag_and_push(self, new_version: str):
+        tag = f"{self.name}-v{new_version}"
+        self._create_and_push_tag(tag)
 
 
 class MuslSupportSDK(SDK):
@@ -40,13 +43,4 @@ class MuslSupportSDK(SDK):
 
     def tag_and_push_musl(self, new_version: str):
         musl_tag = f"{self.name}-musl-v{new_version}"
-        try:
-            subprocess.run(["git", "checkout", "-b", f"release/{musl_tag}"], check=True)
-            subprocess.run(["git", "commit", "-a", "--allow-empty", "-m", f"Release {musl_tag}"], check=True)
-            subprocess.run(["gh", "pr", "create", "--title", f"Release {musl_tag}", "--body", f"Release {musl_tag}"], check=True)
-
-            subprocess.run(["git", "tag", musl_tag], check=True)
-            subprocess.run(["git", "push", "origin", musl_tag], check=True)
-            print(f"Created and pushed MUSL tag: {musl_tag}")
-        except subprocess.CalledProcessError as e:
-            print(f"Error during MUSL git operations: {e}")
+        self._create_and_push_tag(musl_tag)

--- a/release/sdks/base.py
+++ b/release/sdks/base.py
@@ -20,6 +20,8 @@ class SDK(ABC):
         try:
             subprocess.run(["git", "checkout", "-b", f"release/{tag}"], check=True)
             subprocess.run(["git", "commit", "-a", "--allow-empty", "-m", f"Release {tag}"], check=True)
+            subprocess.run(["gh", "pr", "create", "--title", f"Release {tag}", "--body", f"Release {tag}"], check=True)
+
             subprocess.run(["git", "tag", tag], check=True)
             subprocess.run(["git", "push", "origin", tag], check=True)
             print(f"Created and pushed tag: {tag}")
@@ -41,6 +43,8 @@ class MuslSupportSDK(SDK):
         try:
             subprocess.run(["git", "checkout", "-b", f"release/{musl_tag}"], check=True)
             subprocess.run(["git", "commit", "-a", "--allow-empty", "-m", f"Release {musl_tag}"], check=True)
+            subprocess.run(["gh", "pr", "create", "--title", f"Release {musl_tag}", "--body", f"Release {musl_tag}"], check=True)
+
             subprocess.run(["git", "tag", musl_tag], check=True)
             subprocess.run(["git", "push", "origin", musl_tag], check=True)
             print(f"Created and pushed MUSL tag: {musl_tag}")


### PR DESCRIPTION
This pull request includes several changes to update version numbers and refactor the version tagging process for the Flipt Client SDK. The most important changes include updating version numbers in multiple files and refactoring the `tag_and_push` method to improve code reuse.

Version updates:

* [`flipt-client-java/build.gradle`](diffhunk://#diff-4a63bec44c06a86119a7a73356fa8d771036df71984e1b85e5528bc36117242dL11-R11): Updated version from `0.11.0` to `0.12.0`.
* [`flipt-client-java/build.musl.gradle`](diffhunk://#diff-475ec335453b154e069b604264c36943f7889cb81733b56d8ae4401127b97353L11-R11): Updated version from `0.3.0` to `0.4.0`.
* [`flipt-client-node/package-lock.json`](diffhunk://#diff-c43eae3968c5c10eec23858caeaba1740e0210cf2b8418e8195dd70eb1ff9aedL3-R9): Updated version from `0.11.0` to `0.12.0`.
* [`flipt-client-node/package.json`](diffhunk://#diff-5a97f1d0ad1b3af15d3d5a415b9b7fe1e6f69a69d9f0be17ee8a4e2dff703ca7L3-R3): Updated version from `0.11.0` to `0.12.0`.

Refactoring:

* [`release/sdks/base.py`](diffhunk://#diff-62bee65b2e1fa3ffb813f88c45627ce2e252d517b2eeb04ff6141f0bf7b395cfL18-R33): Refactored the `tag_and_push` and `tag_and_push_musl` methods to use a new `_create_and_push_tag` helper method for creating and pushing tags. [[1]](diffhunk://#diff-62bee65b2e1fa3ffb813f88c45627ce2e252d517b2eeb04ff6141f0bf7b395cfL18-R33) [[2]](diffhunk://#diff-62bee65b2e1fa3ffb813f88c45627ce2e252d517b2eeb04ff6141f0bf7b395cfL41-R46)