### PR TITLE
Release flipt-client-ruby-v0.13.0

### DIFF
--- a/flipt-client-ruby/lib/flipt_client/version.rb
+++ b/flipt-client-ruby/lib/flipt_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flipt
-  VERSION = '0.12.0'
+  VERSION = "0.13.0"
 end


### PR DESCRIPTION
Release flipt-client-ruby-v0.13.0