### PR TITLE
Raise Flipt::Error when Flipt API request failed

### DIFF
--- a/flipt-client-ruby/Gemfile.lock
+++ b/flipt-client-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flipt_client (0.12.0)
+    flipt_client (0.13.0)
 
 GEM
   remote: https://rubygems.org/

--- a/flipt-client-ruby/README.md
+++ b/flipt-client-ruby/README.md
@@ -106,7 +106,7 @@ The `FliptEvaluationClient` supports the following authentication strategies:
    docker run -d \
        -p 8080:8080 \
        -p 9000:9000 \
-       docker.flipt.io/flipt/flipt:latest
+       flipt/flipt:latest
    ```
 
 2. You'll also need to have the `flipt_client` gem installed locally. See [Installation](#installation) above.

--- a/flipt-client-ruby/Rakefile
+++ b/flipt-client-ruby/Rakefile
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new('spec')
+
 task default: :spec

--- a/flipt-client-ruby/lib/flipt_client.rb
+++ b/flipt-client-ruby/lib/flipt_client.rb
@@ -92,7 +92,7 @@ module Flipt
       resp, ptr = self.class.evaluate_variant(@engine, evaluation_request.to_json)
       ptr = FFI::AutoPointer.new(ptr, EvaluationClient.method(:destroy_string))
       data = JSON.parse(resp)
-      raise StandardError, data['error_message'] if data['status'] != 'success'
+      raise Error, data['error_message'] if data['status'] != 'success'
 
       data['result']
     end
@@ -107,7 +107,7 @@ module Flipt
       resp, ptr = self.class.evaluate_boolean(@engine, evaluation_request.to_json)
       ptr = FFI::AutoPointer.new(ptr, EvaluationClient.method(:destroy_string))
       data = JSON.parse(resp)
-      raise StandardError, data['error_message'] if data['status'] != 'success'
+      raise Error, data['error_message'] if data['status'] != 'success'
 
       data['result']
     end
@@ -125,7 +125,7 @@ module Flipt
       resp, ptr = self.class.evaluate_batch(@engine, batch_evaluation_request.to_json)
       ptr = FFI::AutoPointer.new(ptr, EvaluationClient.method(:destroy_string))
       data = JSON.parse(resp)
-      raise StandardError, data['error_message'] if data['status'] != 'success'
+      raise Error, data['error_message'] if data['status'] != 'success'
 
       data['result']
     end
@@ -135,7 +135,7 @@ module Flipt
       resp, ptr = self.class.list_flags(@engine)
       ptr = FFI::AutoPointer.new(ptr, EvaluationClient.method(:destroy_string))
       data = JSON.parse(resp)
-      raise StandardError, data['error_message'] if data['status'] != 'success'
+      raise Error, data['error_message'] if data['status'] != 'success'
 
       data['result']
     end

--- a/flipt-client-ruby/spec/evaluation_spec.rb
+++ b/flipt-client-ruby/spec/evaluation_spec.rb
@@ -70,14 +70,14 @@ RSpec.describe Flipt::EvaluationClient do
   describe '#evaluate_variant failure' do
     it 'gracefully handles failures for variant flag evaluation' do
       expect { @client.evaluate_variant({ flag_key: 'nonexistent', entity_id: 'someentity', context: { "fizz": 'buzz' } }) }
-        .to raise_error(StandardError, 'invalid request: failed to get flag information default/nonexistent')
+        .to raise_error(::Flipt::Error, 'invalid request: failed to get flag information default/nonexistent')
     end
   end
 
   describe '#evaluate_boolean failure' do
     it 'gracefully handles failures for boolean flag evaluation' do
       expect { @client.evaluate_boolean({ flag_key: 'nonexistent', entity_id: 'someentity', context: { "fizz": 'buzz' } }) }
-        .to raise_error(StandardError, 'invalid request: failed to get flag information default/nonexistent')
+        .to raise_error(::Flipt::Error, 'invalid request: failed to get flag information default/nonexistent')
     end
   end
 


### PR DESCRIPTION
This pull request updates error handling in the flipt-client-ruby. Previously, the gem raised a generic StandardError when API requests failed. With this change, the gem now raises a more specific Flipt::Error to improve error context and consistency.

Thanks!