### PR TITLE
Revert "build(java): try to inherit build config/deps from main build.gradle"

### DIFF
--- a/flipt-client-java/build.musl.gradle
+++ b/flipt-client-java/build.musl.gradle
@@ -1,12 +1,103 @@
-apply from: 'build.gradle'
+import java.nio.file.Files
 
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+    id 'signing'
+    id "com.diffplug.spotless" version "6.25.0"
+}
+
+group = 'io.flipt'
 version = '0.4.1'
+description = 'Flipt Client SDK'
+
+java {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+    withSourcesJar()
+    withJavadocJar()
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.17.2'
+    implementation 'net.java.dev.jna:jna-platform:5.15.0'
+    testImplementation platform('org.junit:junit-bom:5.11.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+spotless {
+    java {
+        importOrder()
+
+        removeUnusedImports()
+
+        cleanthat()
+
+        googleJavaFormat()
+
+        formatAnnotations()
+    }
+}
+
+test {
+    useJUnitPlatform()
+}
 
 publishing {
     publications {
         maven(MavenPublication) {
             artifactId = 'flipt-client-java-musl'
             from components.java
+
+            pom {
+                name = 'Flipt Client Java SDK'
+                description = 'Flipt Client Java SDK'
+                url = 'https://github.com/flipt-io/flipt-client-sdks/tree/main/flipt-client-java'
+
+                licenses {
+                    license {
+                        name = 'MIT'
+                        url = 'https://opensource.org/license/mit/'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'flipt-io'
+                        name = 'Flipt'
+                        email = 'devs@flipt.io'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/flipt-io/flipt-client-sdks.git'
+                    developerConnection = 'scm:git:ssh://github.com/flipt-io/flipt-client-sdks.git'
+                    url = 'https://github.com/flipt-io/flipt-client-sdks/tree/main/flipt-client-java'
+                }
+            }
         }
     }
+    repositories {
+        maven {
+            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username "$System.env.MAVEN_USERNAME"
+                password "$System.env.MAVEN_PASSWORD"
+            }
+        }
+    }
+}
+
+signing {
+    def signingKey = System.getenv('PGP_PRIVATE_KEY')
+    def signingPassphrase = System.getenv('PGP_PASSPHRASE')
+    useInMemoryPgpKeys(signingKey, signingPassphrase)
+    sign publishing.publications.maven
 }


### PR DESCRIPTION
Reverts flipt-io/flipt-client-sdks#600

doesnt work

```
flipt-client-sdks/flipt-client-java - [main] » ./gradlew build --build-file build.musl.gradle

FAILURE: Build failed with an exception.

* Where:
Script '/Users/markphelps/workspace/flipt-client-sdks/flipt-client-java/build.gradle' line: 3

* What went wrong:
Could not compile script '/Users/markphelps/workspace/flipt-client-sdks/flipt-client-java/build.gradle'.
> startup failed:
  script '/Users/markphelps/workspace/flipt-client-sdks/flipt-client-java/build.gradle': 3: Only Project and Settings build scripts can contain plugins {} blocks
  
  For more information on the plugins {} block, please refer to https://docs.gradle.org/8.5/userguide/plugins.html#sec:plugins_block in the Gradle documentation.
  
   @ line 3, column 1.
     plugins {
     ^
  
  1 error
```