### PR TITLE
chore: dont run notify workflow on forks

### DIFF
--- a/.github/workflows/package-ffi-engine.yml
+++ b/.github/workflows/package-ffi-engine.yml
@@ -163,6 +163,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     needs: build
+    if: github.repository == 'flipt-io/flipt-client-sdks'
     steps:
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
the secrets dont exist on forked repos, so skip this job as it will always fail