### PR TITLE
chore: try to fix issue with dagger and host platform

### DIFF
--- a/.github/workflows/package-ffi-sdks.yml
+++ b/.github/workflows/package-ffi-sdks.yml
@@ -30,7 +30,7 @@ env:
   PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
   GO_VERSION: "1.23"
-  DAGGER_VERSION: "0.12.3"
+  DAGGER_VERSION: "0.14.0"
 
 jobs:
   build:

--- a/.github/workflows/package-wasm-sdks.yml
+++ b/.github/workflows/package-wasm-sdks.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   NPM_API_KEY: ${{ secrets.NPM_API_KEY }}
   GO_VERSION: "1.22"
-  DAGGER_VERSION: "0.12.3"
+  DAGGER_VERSION: "0.14.0"
 
 jobs:
   build:

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   GO_VERSION: "1.22"
-  DAGGER_VERSION: "0.12.3"
+  DAGGER_VERSION: "0.14.0"
 
 jobs:
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,14 @@ You don't have to build the engine from scratch in order to develop a new client
 
 ### 4. Setup Tests (optional)
 
+Prerequisites:
+
+- [Dagger](https://docs.dagger.io/install/#stable-release)
+- [Go](https://go.dev/dl/)
+- [Docker](https://docs.docker.com/get-docker/)
+
+See the [test/README.md](./test/README.md) for more information on how to setup tests for the new client.
+
 If you'd like to add tests using Dagger, you can follow the steps below. If you are not familiar with Dagger, you can skip this step and simply provide instructions for running the tests locally.
 
 Feel free to ask the team for help with this step.
@@ -75,8 +83,6 @@ Feel free to ask the team for help with this step.
 1. Update the `test/main.go` file to include the new client in the list of clients to test.
 2. Update `test/main.go` to run the tests for the new client using Dagger. See the existing clients for examples.
 3. Ensure the tests pass locally by running `dagger run go run ./test/... -sdks {comma separated list of languages}` from the root of the repository. Note: You will need to have Docker, Go, and Dagger installed locally to run the tests.
-
-> **Note:** If you are working on an ARM-based cpu then you may encounter an OSError `cannot open shared object file: No such file or directory`. This could be due to the `getFFITestContainer()` step of the dagger pipeline building the dynamic library for an ARM target which cannot be used by the tests. A workaround until this is resolved is downloading the x86 `.so` from the [releases page](https://github.com/flipt-io/flipt-client-sdks/releases/latest), moving the `.so` to the expected folder (which will get mounted to the container for tests), and removing any `WithFile` directives from `test/main.go` which might override your local copy with the ARM-based copy compiled in `getFFITestContainer()`
 
 ### 5. Update README
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,32 +37,8 @@ Releasing the engine is a three-step process:
 
 #### SDKs
 
-Releasing each SDK is a two to three-step process:
-
 <p align="center">
     <img src=".github/images/release-engine-ffi-sdk.png" width=600 />
 </p>
 
-1. Update the SDK to the new version that you want to release (i.e. update the version in `package.json` for Node, `pyproject.toml` for Python, `flipt_client.gemspec` for Ruby).
-1. Commit and tag the SDK with the new version using the naming convention `flipt-client-{language}-{version}` (i.e. `flipt-client-node-v0.1.0`).
-1. Push the tag to `origin`. This will trigger the appropriate GitHub Action to build, package, and publish the SDK.
-
-Note: In the future we can potentially automate the tagging/pushing of the SDKs via a GitHub Action or script.
-
-#### Checklist
-
-- [ ] Update the `flipt-client-node` version in `flipt-client-node/package.json` and run `npm install`
-- [ ] Update the `flipt-client-python` version in `flipt-client-python/pyproject.toml`
-- [ ] Update the `flipt-client-ruby` version in `flipt-client-ruby/lib/flipt_client/version.rb`
-- [ ] Update the `flipt-client-java` version in `flipt-client-java/build.gradle`
-- [ ] Update the `flipt-client-dart` version in `flipt-client-dart/pubspec.yaml`
-- [ ] Tag each SDK with the new version and push the tags to `origin`
-
-### WASM
-
-Releasing the `flipt-client-browser` SDK is a three to four-step process:
-
-1. Update the `flipt-engine-wasm` dependency in `flipt-client-browser/src` (if necessary).
-1. Update the `flipt-client-browser` version in `flipt-client-browser/package.json` and run `npm install`
-1. Commit and tag the SDK with the new version using the naming convention `flipt-client-browser-v{version}` (i.e. `flipt-client-browser-v0.1.0`).
-1. Push the tag to `origin`. This will trigger the appropriate GitHub Action to build, package, and publish the SDK.
+We use a Python script to release the SDKs. The script is located in the [release](./release) directory. See the [README](./release/README.md) for more information.

--- a/release/README.md
+++ b/release/README.md
@@ -43,66 +43,17 @@ python release.py
 
 1. **SDK Selection**: The script presents a list of available SDKs and allows the user to select which ones to update.
 
-2. **Action Selection**: The user chooses whether to update versions, tag and push, or both.
+2. **Version Bump Selection**: The user selects the type of version bump (patch, minor, or major).
 
-3. **Version Bump Selection**: If updating versions, the user selects the type of version bump (patch, minor, or major).
-
-4. **Version Update**: For each selected SDK, the script:
+3. **Version Update**: For each selected SDK, the script:
 
    - Reads the current version
    - Calculates the new version based on the bump type
    - Updates the version in the SDK-specific file (e.g., package.json, build.gradle)
 
-5. **Tagging and Pushing**: If selected, the script creates Git tags for the new versions and pushes them to the remote repository.
+4. **Tagging and Pushing**: The script creates Git tags for the new versions and pushes them to the remote repository.
 
-## SDK-Specific Handling
-
-The script uses separate classes for each SDK type to handle version reading and updating:
-
-```12:23:release/release.py
-def get_sdk(name: str, path: str) -> SDK:
-    sdk_classes = {
-        "flipt-client-go": GoSDK,
-        "flipt-client-java": JavaSDK,
-        "flipt-client-node": JavaScriptSDK,
-        "flipt-client-browser": JavaScriptSDK,
-        "flipt-client-react": JavaScriptSDK,
-        "flipt-client-dart": DartSDK,
-        "flipt-client-python": PythonSDK,
-        "flipt-client-ruby": RubySDK,
-    }
-    return sdk_classes[name](name, path)
-```
-
-Each SDK class implements methods for getting the current version, updating the version, and handling MUSL versions if applicable.
-
-## MUSL Support
-
-Some SDKs (like Java and Go) have MUSL versions. The script handles these separately:
-
-```69:73:release/release.py
-        if isinstance(sdk, MuslSupportSDK):
-            current_musl_version = sdk.get_current_musl_version()
-            new_musl_version = bump_version(current_musl_version, bump_type)
-            sdk.update_musl_version(new_musl_version)
-            updated_versions[f"{sdk_dir}-musl"] = new_musl_version
-```
-
-## Error Handling
-
-The script includes error handling to manage issues such as:
-
-- Missing SDK directories
-- Failures in reading or writing version files
-- Git tagging or pushing errors
-
-## Customization
-
-To add support for a new SDK:
-
-1. Create a new SDK class in the `sdks` directory
-2. Implement the required methods (`get_current_version`, `update_version`)
-3. Add the new SDK to the `sdk_classes` dictionary in the `get_sdk` function
+5. **Pull Request**: The script optionally creates a pull request with the versioning changes.
 
 ## Notes
 

--- a/test/README.md
+++ b/test/README.md
@@ -6,9 +6,10 @@ In the `test/` directory we will use [Dagger](https://dagger.io/) to orchestrate
 
 ## Requirements
 
-Make sure you have `dagger` installed. This module is pinned to `v0.9.3` currently.
+Make sure you have `dagger` installed. This module is pinned to `v0.14.0` currently in CI. 
 
-Here are the [Dagger Installation Instructions](https://docs.dagger.io/quickstart/729236/cli).
+> [!IMPORTANT]
+> We recommend installing the same version of Dagger as is used in CI. Follow the [Dagger Installation Instructions](https://docs.dagger.io/install/#stable-release) to install the correct version (v0.14.0).
 
 ## Running Tests
 


### PR DESCRIPTION
Try to fix: #650 

@atmask mind giving this PR a try to see if it fixes the issue? I wonder if it has something to do with Rosetta like you mentioned. Hopefully specifying the platform for the rust image / lib compilation step fixes it

This pull request includes multiple changes across different files to update the Dagger version, enhance documentation, and improve the test setup. The most important changes are summarized below:

### Version Updates:
* Updated `DAGGER_VERSION` to `0.14.0` in `.github/workflows/package-ffi-sdks.yml` [[1]](diffhunk://#diff-109442fada4c603b457d3f8bb0aaefccf0638b63f00034797ed638296b59eb43L33-R33) `.github/workflows/package-wasm-sdks.yml` [[2]](diffhunk://#diff-13097cada9ececf2999d0023083271317c506d44a1a9fd5167498674f7b21227L16-R16) and `.github/workflows/test-sdks.yml` [[3]](diffhunk://#diff-88885dea3c854b4f7dcee3423c26b4f0244466086c513b37aaae40851f61509fL13-R13).

### Documentation Enhancements:
* Added prerequisites and additional setup information for tests in `CONTRIBUTING.md` [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R71-R78) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L79-L80).
* Updated `RELEASE.md` to reflect the use of a Python script for releasing SDKs instead of a manual process.
* Updated `release/README.md` to clarify the steps performed by the release script and added an optional pull request creation step.

### Test Configuration:
* Updated `test/README.md` to recommend installing the same Dagger version as used in CI.
* Added `platform` variable to `test/main.go` and updated container creation to use this variable for specifying the platform [[1]](diffhunk://#diff-1f8b50e8ef8367410c84a12043c2bbe24a43dd21a49bfa3fa9af9c80e2fc4ac7R19) [[2]](diffhunk://#diff-1f8b50e8ef8367410c84a12043c2bbe24a43dd21a49bfa3fa9af9c80e2fc4ac7R45-R48) [[3]](diffhunk://#diff-1f8b50e8ef8367410c84a12043c2bbe24a43dd21a49bfa3fa9af9c80e2fc4ac7L99-L103) [[4]](diffhunk://#diff-1f8b50e8ef8367410c84a12043c2bbe24a43dd21a49bfa3fa9af9c80e2fc4ac7L160-R160) [[5]](diffhunk://#diff-1f8b50e8ef8367410c84a12043c2bbe24a43dd21a49bfa3fa9af9c80e2fc4ac7L174-R176).