### PR TITLE
Use ClientOptions type in provider to allow for authentication

### DIFF
--- a/flipt-client-react/src/provider.tsx
+++ b/flipt-client-react/src/provider.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { FliptContext, useStore } from './useFliptClient';
+import type { ClientOptions } from '@flipt-io/flipt-client-browser';
 
 export const FliptProvider: React.FC<{
   children: React.ReactNode;
   namespace: string;
-  options: { url: string; updateInterval?: number };
+  options: ClientOptions;
 }> = ({ children, namespace, options }) => {
   const [store] = useState(useStore(namespace, options));
   useEffect(() => {


### PR DESCRIPTION
Was getting a type error when trying to add authentication to the provider.

NB: First time contributing. Realise there may be room for improvement.