### PR TITLE
chore: specify Cmake version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,16 @@ updates:
       # kodiak `merge.automerge_label`
       - "automerge"
 
+  - package-ecosystem: gradle
+    directory: "/flipt-client-kotlin-android"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      # kodiak `merge.automerge_label`
+      - "automerge"
+
   - package-ecosystem: bundler
     directory: "/flipt-client-ruby"
     schedule:

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -89,6 +89,11 @@ jobs:
             sleep 1
           done
 
+      - name: Install CMake
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "3.19.8"
+
       - name: Run Integration Tests
         uses: reactivecircus/android-emulator-runner@v2
         env:

--- a/flipt-client-kotlin-android/build.gradle
+++ b/flipt-client-kotlin-android/build.gradle
@@ -41,7 +41,6 @@ android {
 
     externalNativeBuild {
         cmake {
-            version "3.19.8"
             path "src/main/cpp/CMakeLists.txt"
         }
     }

--- a/flipt-client-kotlin-android/build.gradle
+++ b/flipt-client-kotlin-android/build.gradle
@@ -41,6 +41,7 @@ android {
 
     externalNativeBuild {
         cmake {
+            version "3.19.8"
             path "src/main/cpp/CMakeLists.txt"
         }
     }


### PR DESCRIPTION
try to fix this warning:

```
C/C++: CMake Warning at /usr/local/lib/android/sdk/ndk/25.1.8937393/build/cmake/android-legacy.toolchain.cmake:415 (message):
C/C++:   An old version of CMake is being used that cannot automatically detect
C/C++:   compiler attributes.  Compiler identification is being bypassed.  Some
C/C++:   values may be wrong or missing.  Update to CMake 3.19 or newer to use
C/C++:   CMake's built-in compiler identification.
C/C++: Call Stack (most recent call first):
C/C++:   /usr/local/lib/android/sdk/ndk/25.1.8937393/build/cmake/android.toolchain.cmake:54 (include)
C/C++:   /home/runner/work/flipt-client-sdks/flipt-client-sdks/flipt-client-kotlin-android/.cxx/Debug/2m5n4r4i/x86_64/CMakeFiles/3.18.1-g262b901/CMakeSystem.cmake:6 (include)
C/C++:   /home/runner/work/flipt-client-sdks/flipt-client-sdks/flipt-client-kotlin-android/.cxx/Debug/2m5n4r4i/x86_64/CMakeFiles/CMakeTmp/CMakeLists.txt:2 (project)
C/C++: CMake Warning at /usr/local/lib/android/sdk/ndk/25.1.8937393/build/cmake/android-legacy.toolchain.cmake:415 (message):
C/C++:   An old version of CMake is being used that cannot automatically detect
C/C++:   compiler attributes.  Compiler identification is being bypassed.  Some
C/C++:   values may be wrong or missing.  Update to CMake 3.19 or newer to use
C/C++:   CMake's built-in compiler identification.
C/C++: Call Stack (most recent call first):
C/C++:   /usr/local/lib/android/sdk/ndk/25.1.8937393/build/cmake/android.toolchain.cmake:54 (include)
```