### PR TITLE
chore: try to share dependency versions for java sdk

### DIFF
--- a/flipt-client-java/build.gradle
+++ b/flipt-client-java/build.gradle
@@ -23,11 +23,11 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.2'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2'
-    implementation 'net.java.dev.jna:jna-platform:5.16.0'
-    testImplementation platform('org.junit:junit-bom:5.11.4')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation libs.jackson.dataformat.xml
+    implementation libs.jackson.datatype.jdk8
+    implementation libs.jna.platform
+    testImplementation platform(libs.junit.bom)
+    testImplementation libs.junit.jupiter
 }
 
 spotless {

--- a/flipt-client-java/build.musl.gradle
+++ b/flipt-client-java/build.musl.gradle
@@ -23,11 +23,11 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.2'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.17.2'
-    implementation 'net.java.dev.jna:jna-platform:5.15.0'
-    testImplementation platform('org.junit:junit-bom:5.11.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation libs.jackson.dataformat.xml
+    implementation libs.jackson.datatype.jdk8
+    implementation libs.jna.platform
+    testImplementation platform(libs.junit.bom)
+    testImplementation libs.junit.jupiter
 }
 
 spotless {

--- a/flipt-client-java/gradle/libs.versions.toml
+++ b/flipt-client-java/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+jackson = "2.18.2"
+jna = "5.16.0"
+junit = "5.11.4"
+
+[libraries]
+jackson-dataformat-xml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-xml", version.ref = "jackson" }
+jackson-datatype-jdk8 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8", version.ref = "jackson" }
+jna-platform = { group = "net.java.dev.jna", name = "jna-platform", version.ref = "jna" }
+junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }
+
+[plugins]

--- a/flipt-client-java/gradle/libs.versions.toml
+++ b/flipt-client-java/gradle/libs.versions.toml
@@ -9,5 +9,3 @@ jackson-datatype-jdk8 = { group = "com.fasterxml.jackson.datatype", name = "jack
 jna-platform = { group = "net.java.dev.jna", name = "jna-platform", version.ref = "jna" }
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }
-
-[plugins]


### PR DESCRIPTION
try to use [gradle catalogs](https://docs.gradle.org/current/userguide/version_catalogs.html) to share dependency versions (for dependabot updates) between the glibc and musl version of the Java SDK