### PR TITLE
chore: try to fix swift SDK release

### DIFF
--- a/.github/workflows/package-ffi-engine.yml
+++ b/.github/workflows/package-ffi-engine.yml
@@ -163,17 +163,23 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     needs: build
+    env:
+      FLIPT_RELEASE_BOT_APP_ID: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+      FLIPT_RELEASE_BOT_APP_PEM: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+      FLIPT_RELEASE_BOT_INSTALLATION_ID: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
     if: github.repository == 'flipt-io/flipt-client-sdks'
     steps:
       - name: Generate token
         id: generate_token
+        if: env.FLIPT_RELEASE_BOT_APP_ID != '' && env.FLIPT_RELEASE_BOT_APP_PEM != '' && env.FLIPT_RELEASE_BOT_INSTALLATION_ID != ''
         uses: tibdex/github-app-token@v2
         with:
-          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
-          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
-          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+          app_id: ${{ env.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ env.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ env.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
 
       - name: Trigger Test Android SDK
+        if: steps.generate_token.outputs.token != ''
         run: |
           curl -X POST -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
Re: #670 

- Adds missing macos targets for swift packaging
- Uses GitHub API to create a release after tagging for Swift and Go SDKs as they require separate repos