### PR TITLE
feat: rename report error strategy to fail

### DIFF
--- a/flipt-client-csharp/README.md
+++ b/flipt-client-csharp/README.md
@@ -71,6 +71,7 @@ The `EvaluationClient` constructor accepts two optional arguments:
   - `Authentication`: The authentication strategy to use when communicating with the upstream Flipt instance. If not provided, the client will default to no authentication. See the [Authentication](#authentication) section for more information.
   - `Reference`: The [reference](https://docs.flipt.io/guides/user/using-references) to use when fetching flag state. If not provided, reference will not be used.
   - `FetchMode`: The fetch mode to use when fetching flag state. If not provided, the client will default to polling.
+  - `ErrorStrategy`: The error strategy to use when fetching flag state. If not provided, the client will default to `Fail`. See the [Error Strategies](#error-strategies) section for more information.
 
 ### Authentication
 
@@ -79,6 +80,13 @@ The `EvaluationClient` supports the following authentication strategies:
 - No Authentication (default)
 - [Client Token Authentication](https://docs.flipt.io/authentication/using-tokens)
 - [JWT Authentication](https://docs.flipt.io/authentication/using-jwts)
+
+### Error Strategies
+
+The `EvaluationClient` supports the following error strategies:
+
+- `Fail`: The client will throw an error if the flag state cannot be fetched. This is the default behavior.
+- `Fallback`: The client will maintain the last known good state and use that state for evaluation in case of an error.
 
 ## Contributing
 

--- a/flipt-client-csharp/src/FliptClient/Models/ClientOptions.cs
+++ b/flipt-client-csharp/src/FliptClient/Models/ClientOptions.cs
@@ -25,7 +25,7 @@ namespace FliptClient.Models
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("error_strategy")]
-        public ErrorStrategy ErrorStrategy { get; set; } = ErrorStrategy.Report;
+        public ErrorStrategy ErrorStrategy { get; set; } = ErrorStrategy.Fail;
     }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/flipt-client-csharp/src/FliptClient/Models/ClientOptions.cs
+++ b/flipt-client-csharp/src/FliptClient/Models/ClientOptions.cs
@@ -31,8 +31,8 @@ namespace FliptClient.Models
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum ErrorStrategy
     {
-        [JsonPropertyName("report")]
-        Report,
+        [JsonPropertyName("fail")]
+        Fail,
         [JsonPropertyName("fallback")]
         Fallback,
     }

--- a/flipt-client-go/README.md
+++ b/flipt-client-go/README.md
@@ -103,6 +103,7 @@ The `NewClient` constructor accepts a variadic number of `ClientOption` function
 - `With{Method}Authentication`: The authentication strategy to use when communicating with the upstream Flipt instance. If not provided, the client will default to no authentication. See the [Authentication](#authentication) section for more information.
 - `WithReference`: The [reference](https://docs.flipt.io/guides/user/using-references) to use when fetching flag state. If not provided, reference will not be used.
 - `WithFetchMode`: The fetch mode to use when fetching flag state. If not provided, the client will default to polling.
+- `WithErrorStrategy`: The error strategy to use when fetching flag state. If not provided, the client will default to `Fail`. See the [Error Strategies](#error-strategies) section for more information.
 
 ### Authentication
 
@@ -111,6 +112,13 @@ The `Client` supports the following authentication strategies:
 - No Authentication (default)
 - [Client Token Authentication](https://docs.flipt.io/authentication/using-tokens)
 - [JWT Authentication](https://docs.flipt.io/authentication/using-jwts)
+
+### Error Strategies
+
+The `Client` supports the following error strategies:
+
+- `Fail`: The client will throw an error if the flag state cannot be fetched. This is the default behavior.
+- `Fallback`: The client will maintain the last known good state and use that state for evaluation in case of an error.
 
 ## Memory Management
 

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -30,6 +30,7 @@ type EvaluationClient struct {
 	ref            string
 	updateInterval int
 	fetchMode      FetchMode
+	errorStrategy  ErrorStrategy
 }
 
 // NewEvaluationClient constructs a Client.
@@ -48,6 +49,7 @@ func NewEvaluationClient(opts ...clientOption) (*EvaluationClient, error) {
 		Authentication: &client.authentication,
 		Reference:      client.ref,
 		FetchMode:      client.fetchMode,
+		ErrorStrategy:  client.errorStrategy,
 	}
 
 	b, err := json.Marshal(clientOpts)
@@ -113,6 +115,13 @@ func WithJWTAuthentication(token string) clientOption {
 func WithFetchMode(fetchMode FetchMode) clientOption {
 	return func(c *EvaluationClient) {
 		c.fetchMode = fetchMode
+	}
+}
+
+// WithErrorStrategy allows for specifying the error strategy for the Flipt client when fetching flag state (e.g. fail, fallback).
+func WithErrorStrategy(errorStrategy ErrorStrategy) clientOption {
+	return func(c *EvaluationClient) {
+		c.errorStrategy = errorStrategy
 	}
 }
 

--- a/flipt-client-go/models.go
+++ b/flipt-client-go/models.go
@@ -21,12 +21,20 @@ const (
 	FetchModePolling   FetchMode = "polling"
 )
 
+type ErrorStrategy string
+
+const (
+	ErrorStrategyFail     ErrorStrategy = "fail"
+	ErrorStrategyFallback ErrorStrategy = "fallback"
+)
+
 type clientOptions[T any] struct {
-	URL            string    `json:"url,omitempty"`
-	Authentication *T        `json:"authentication,omitempty"`
-	UpdateInterval int       `json:"update_interval,omitempty"`
-	Reference      string    `json:"reference,omitempty"`
-	FetchMode      FetchMode `json:"fetch_mode,omitempty"`
+	URL            string        `json:"url,omitempty"`
+	Authentication *T            `json:"authentication,omitempty"`
+	UpdateInterval int           `json:"update_interval,omitempty"`
+	Reference      string        `json:"reference,omitempty"`
+	FetchMode      FetchMode     `json:"fetch_mode,omitempty"`
+	ErrorStrategy  ErrorStrategy `json:"error_strategy,omitempty"`
 }
 
 type Flag struct {

--- a/flipt-engine-ffi/examples/evaluation.rs
+++ b/flipt-engine-ffi/examples/evaluation.rs
@@ -14,7 +14,7 @@ fn main() {
         .build();
     let evaluator = Evaluator::new(namespace);
 
-    let engine = fliptengine::Engine::new(namespace, fetcher, evaluator, ErrorStrategy::Report);
+    let engine = fliptengine::Engine::new(namespace, fetcher, evaluator, ErrorStrategy::Fail);
     let mut context: HashMap<String, String> = HashMap::new();
     context.insert("fizz".into(), "buzz".into());
 

--- a/flipt-engine-ffi/src/http.rs
+++ b/flipt-engine-ffi/src/http.rs
@@ -83,9 +83,9 @@ pub enum FetchMode {
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ErrorStrategy {
-    /// The default behavior: report the error.
+    /// The default behavior: fail fast.
     #[default]
-    Report,
+    Fail,
     /// Fallback: use the previous available Snapshot state.
     Fallback,
 }

--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -97,7 +97,7 @@ impl Default for EngineOpts {
             update_interval: Some(120),
             reference: None,
             fetch_mode: Some(FetchMode::default()),
-            error_strategy: Some(ErrorStrategy::Report),
+            error_strategy: Some(ErrorStrategy::Fail),
         }
     }
 }
@@ -144,7 +144,7 @@ impl Engine {
                         evaluator_clone.lock().unwrap().replace_snapshot(snap);
                     }
                     Err(err) => {
-                        if error_strategy == ErrorStrategy::Report {
+                        if error_strategy == ErrorStrategy::Fail {
                             evaluator_clone.lock().unwrap().replace_snapshot(Err(err));
                         }
                     }


### PR DESCRIPTION
Renames `report` to `fail` for 'fail-fast' as I think report might be a bit confusing as we don't actually 'report' the error as in like report to Sentry or anything. I'm open to other names though

Also add a section in the C# readme explaining this new option. I'd like to release the C# client and then add this new option to the other SDKs as well