### PR TITLE
chore: skip ci on PRs created for version bumps

### DIFF
--- a/release/sdks/base.py
+++ b/release/sdks/base.py
@@ -24,7 +24,7 @@ class SDK(ABC):
         try:
             if create_pull_request:
                 subprocess.run(["git", "checkout", "-b", f"release/{tag}"], check=True, cwd=self.path)
-                subprocess.run(["git", "commit", "-s", "-a", "--allow-empty", "-m", f"Release {tag}"], check=True, cwd=self.path)
+                subprocess.run(["git", "commit", "-s", "-a", "--allow-empty", "-m", f"Release {tag} [ci skip]"], check=True, cwd=self.path)
                 subprocess.run(
                     ["gh", "pr", "create", "-R", "flipt-io/flipt-client-sdks", "--title", f"Release {tag}", "--body", f"Release {tag}"],
                     cwd=self.path


### PR DESCRIPTION
We dont need to run actions on PRs that are created just for version bumps as the actual release will still take place because of the tag being pushed

https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs