### PR TITLE
chore: Packaging for 'static' libs and Go (wasm)

### DIFF
--- a/.github/workflows/package-go-sdk.yml
+++ b/.github/workflows/package-go-sdk.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
       - "flipt-client-go-**"
-      - "flipt-client-go-musl-**"
 
 permissions:
   contents: write
@@ -11,8 +10,8 @@ permissions:
 
 jobs:
   build:
-    uses: ./.github/workflows/package-ffi-sdks.yml
+    uses: ./.github/workflows/package-wasm-sdks.yml
     with:
-      sdks: ${{ startsWith(github.ref, 'refs/tags/flipt-client-go-musl-') && 'go-musl' || 'go' }}
+      sdks: 'go'
       tag: ${{ github.ref }}
     secrets: inherit

--- a/.github/workflows/package-java-sdk.yml
+++ b/.github/workflows/package-java-sdk.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
       - "flipt-client-java-**"
-      - "flipt-client-java-musl-**"
 
 permissions:
   contents: write
@@ -20,5 +19,5 @@ jobs:
   build:
     uses: ./.github/workflows/package-ffi-sdks.yml
     with:
-      sdks: ${{ startsWith(github.ref, 'refs/tags/flipt-client-java-musl-') && 'java-musl' || 'java' }}
+      sdks: "java"
     secrets: inherit

--- a/.github/workflows/package-wasm-sdks.yml
+++ b/.github/workflows/package-wasm-sdks.yml
@@ -6,13 +6,17 @@ on:
         description: "SDK(s) to build"
         type: string
         required: true
+      tag:
+        description: "Tag to use for SDK(s)"
+        type: string
+        required: false
 
 permissions:
   contents: write
 
 env:
   NPM_API_KEY: ${{ secrets.NPM_API_KEY }}
-  GO_VERSION: "1.22"
+  GO_VERSION: "1.23"
   DAGGER_VERSION: "0.14.0"
 
 jobs:
@@ -33,6 +37,16 @@ jobs:
           cd /usr/local
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ env.DAGGER_VERSION }} sh
 
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
       - name: Build Individual SDK(s)
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          dagger run go run ./package/wasm --sdks=${{ inputs.sdks }} --push=true
+          dagger run go run ./package/wasm --sdks=${{ inputs.sdks }} --push=true --tag=${{ inputs.tag }}

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -2,13 +2,34 @@ name: Test Android SDK
 on:
   workflow_run:
     workflows: ["Package FFI Engine (Android)"]
-    types: [completed]
+    types: [requested, completed]
 
 permissions:
   contents: write
   id-token: write
+  statuses: write
 
 jobs:
+  set-status:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == null }}
+    steps:
+      - name: Create Pending Status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: sha,
+              state: 'pending',
+              context: 'Android SDK Tests',
+              description: 'Tests are running...',
+              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            });
+
   test:
     name: Integration Tests
     runs-on: ubuntu-22.04
@@ -107,6 +128,23 @@ jobs:
           script: ./gradlew connectedAndroidTest
           working-directory: ./flipt-client-kotlin-android
           emulator-options: -no-window -no-snapshot -screen no-touch -noaudio -no-boot-anim -camera-back none
+
+      - name: Update Status Check
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: sha,
+              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
+              context: 'Swift SDK Tests',
+              description: '${{ job.status }}' === 'success' ? 'Tests passed' : 'Tests failed',
+              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            });
 
       - name: (Fail-only) Upload the build reports
         if: failure()

--- a/.github/workflows/test-engines.yml
+++ b/.github/workflows/test-engines.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        run: rustup update 1.81.0
+        run: rustup update stable
 
       - name: Check Formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.22"
+  GO_VERSION: "1.23"
   DAGGER_VERSION: "0.14.0"
 
 jobs:
@@ -32,6 +32,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
+          cache: true
 
       - name: Install Dagger
         run: |

--- a/.github/workflows/test-swift-sdk.yml
+++ b/.github/workflows/test-swift-sdk.yml
@@ -2,13 +2,34 @@ name: Test Swift SDK
 on:
   workflow_run:
     workflows: ["Package FFI Engine (Darwin)"]
-    types: [completed]
+    types: [requested, completed]
 
 permissions:
   contents: write
   id-token: write
+  statuses: write
 
 jobs:
+  set-status:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == null }}
+    steps:
+      - name: Create Pending Status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: sha,
+              state: 'pending',
+              context: 'Swift SDK Tests',
+              description: 'Tests are running...',
+              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            });
+
   test:
     name: Integration Tests
     runs-on: macos-14
@@ -129,3 +150,20 @@ jobs:
         run: |
           cd ./flipt-client-swift
           swift test
+
+      - name: Update Status Check
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: sha,
+              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
+              context: 'Swift SDK Tests',
+              description: '${{ job.status }}' === 'success' ? 'Tests passed' : 'Tests failed',
+              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            });

--- a/package/ffi/main.go
+++ b/package/ffi/main.go
@@ -23,7 +23,6 @@ var (
 	engineTag string
 	sdksToFn  = map[string]sdks.SDK{
 		"python": &sdks.PythonSDK{},
-		"go":     &sdks.GoSDK{},
 		"ruby":   &sdks.RubySDK{},
 		"java":   &sdks.JavaSDK{},
 		"dart":   &sdks.DartSDK{},

--- a/package/ffi/sdks/go.go
+++ b/package/ffi/sdks/go.go
@@ -38,12 +38,12 @@ func (s *GoSDK) Build(ctx context.Context, client *dagger.Client, hostDirectory 
 
 	git := client.Container().From("golang:1.21.3-bookworm").
 		WithSecretVariable("GITHUB_TOKEN", ghToken).
-		WithExec([]string{"git", "config", "--global", "user.email", gitUserEmail}).
-		WithExec([]string{"git", "config", "--global", "user.name", gitUserName}).
-		WithExec([]string{"sh", "-c", `git config --global http.https://github.com/.extraheader "AUTHORIZATION: Basic ${GITHUB_TOKEN}"`})
+		WithExec(args("git config --global user.email %s", gitUserEmail)).
+		WithExec(args("git config --global user.name %s", gitUserName)).
+		WithExec(args("sh -c 'git config --global http.https://github.com/.extraheader \"AUTHORIZATION: Basic ${GITHUB_TOKEN}\"'"))
 
 	repository := git.
-		WithExec([]string{"git", "clone", "https://github.com/flipt-io/flipt-client-sdks.git", "/src"}).
+		WithExec(args("git clone https://github.com/flipt-io/flipt-client-sdks.git /src")).
 		WithWorkdir("/src").
 		WithFile("/tmp/ext/flipt_engine.h", hostDirectory.File("flipt-engine-ffi/include/flipt_engine.h")).
 		WithDirectory("/tmp/ext", hostDirectory.Directory("tmp"), dagger.ContainerWithDirectoryOpts{Include: defaultInclude})

--- a/package/ffi/sdks/swift.go
+++ b/package/ffi/sdks/swift.go
@@ -21,7 +21,6 @@ func (s *SwiftSDK) SupportedPlatforms() []platform.Platform {
 		platform.IOSArm64,
 		platform.IOSSimArm64,
 		platform.DarwinArm64,
-		platform.DarwinX86_64,
 	}
 }
 

--- a/package/ffi/sdks/swift.go
+++ b/package/ffi/sdks/swift.go
@@ -31,8 +31,8 @@ func (s *SwiftSDK) Build(ctx context.Context, client *dagger.Client, hostDirecto
 	}
 
 	var (
-		encodedPAT = base64.URLEncoding.EncodeToString([]byte("pat:" + pat))
-		ghToken    = client.SetSecret("gh-token", encodedPAT)
+		secretPAT        = client.SetSecret("gh-token", pat)
+		secretEncodedPAT = client.SetSecret("gh-token-encoded", base64.URLEncoding.EncodeToString([]byte("pat:"+pat)))
 	)
 
 	var gitUserName = os.Getenv("GIT_USER_NAME")
@@ -46,7 +46,7 @@ func (s *SwiftSDK) Build(ctx context.Context, client *dagger.Client, hostDirecto
 	}
 
 	git := client.Container().From("golang:1.21.3-bookworm").
-		WithSecretVariable("GITHUB_TOKEN", ghToken).
+		WithSecretVariable("GITHUB_TOKEN", secretEncodedPAT).
 		WithExec(args("git config --global user.email %s", gitUserEmail)).
 		WithExec(args("git config --global user.name %s", gitUserName)).
 		WithExec(args("sh -c 'git config --global http.https://github.com/.extraheader \"AUTHORIZATION: Basic ${GITHUB_TOKEN}\"'"))
@@ -101,14 +101,16 @@ func (s *SwiftSDK) Build(ctx context.Context, client *dagger.Client, hostDirecto
 
 	// create GitHub release via API
 	releasePayload := fmt.Sprintf(`{"tag_name":"%s","name":"%s","body":"Release %s of the Flipt Swift Client SDK"}`, targetTag, targetTag, targetTag)
-	_, err = filtered.WithExec([]string{
-		"curl",
-		"-X", "POST",
-		"-H", fmt.Sprintf("Authorization: token %s", pat),
-		"-H", "Accept: application/vnd.github.v3+json",
-		"-d", releasePayload,
-		fmt.Sprintf("https://api.github.com/repos/flipt-io/flipt-client-swift/releases"),
-	}).Sync(ctx)
+	_, err = filtered.
+		WithSecretVariable("GITHUB_TOKEN", secretPAT).
+		WithExec([]string{
+			"curl",
+			"-X", "POST",
+			"-H", "Authorization: token $GITHUB_TOKEN",
+			"-H", "Accept: application/vnd.github.v3+json",
+			"-d", releasePayload,
+			"https://api.github.com/repos/flipt-io/flipt-client-swift/releases",
+		}).Sync(ctx)
 
 	return err
 }

--- a/package/wasm/main.go
+++ b/package/wasm/main.go
@@ -5,20 +5,29 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"strings"
 
 	"dagger.io/dagger"
+	"go.flipt.io/flipt/client-sdks/package/wasm/sdks"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
-	sdks string
-	push bool
-	tag  string
+	selected string
+	push     bool
+	tag      string
+	sdksToFn = map[string]sdks.SDK{
+		"node":    &sdks.NodeSDK{},
+		"browser": &sdks.BrowserSDK{},
+		"go":      &sdks.GoSDK{},
+	}
+	sema = make(chan struct{}, 5)
 )
 
 func init() {
-	flag.StringVar(&sdks, "sdks", "", "comma separated list of which sdks(s) to run builds for")
+	flag.StringVar(&selected, "sdks", "", "comma separated list of which sdks(s) to run builds for")
 	flag.BoolVar(&push, "push", false, "push built artifacts to registry")
 	flag.StringVar(&tag, "tag", "", "tag to use for release")
 }
@@ -31,18 +40,34 @@ func main() {
 	}
 }
 
-type buildFn func(context.Context, *dagger.Client, *dagger.Directory) error
+func take(fn func() error) func() error {
+	return func() error {
+		// insert into semaphore channel to maintain
+		// a max concurrency
+		sema <- struct{}{}
+		defer func() { <-sema }()
+
+		return fn()
+	}
+}
 
 func run() error {
-	var build buildFn
+	var builds = make(map[string]sdks.SDK, len(sdksToFn))
 
-	switch sdks {
-	case "browser":
-		build = browserBuild
-	case "node":
-		build = nodeBuild
-	default:
-		return fmt.Errorf("no builds specified")
+	maps.Copy(builds, sdksToFn)
+
+	if selected != "" {
+		l := strings.Split(selected, ",")
+		subset := make(map[string]sdks.SDK, len(l))
+		for _, sdk := range l {
+			testFn, ok := sdksToFn[sdk]
+			if !ok {
+				return fmt.Errorf("sdk %s is not supported", sdk)
+			}
+			subset[sdk] = testFn
+		}
+
+		builds = subset
 	}
 
 	ctx := context.Background()
@@ -58,82 +83,16 @@ func run() error {
 		Exclude: []string{".github/", "package/", "test/", ".git/"},
 	})
 
-	return build(ctx, client, dir)
-}
+	var g errgroup.Group
 
-func args(args string, a ...any) []string {
-	if len(a) == 0 {
-		return strings.Split(args, " ")
-	}
-	return strings.Split(fmt.Sprintf(args, a...), " ")
-}
-
-func buildWasm(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory, target string, clientDir string) error {
-	rust := client.Container().From("rust:1.83.0-bookworm").
-		WithWorkdir("/src").
-		WithDirectory("/src/flipt-engine-ffi", hostDirectory.Directory("flipt-engine-ffi")).
-		WithDirectory("/src/flipt-engine-wasm", hostDirectory.Directory("flipt-engine-wasm"), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"pkg/", ".gitignore"},
-		}).
-		WithDirectory("/src/flipt-engine-wasm-js", hostDirectory.Directory("flipt-engine-wasm-js"), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"pkg/", ".gitignore"},
-		}).
-		WithDirectory("/src/flipt-evaluation", hostDirectory.Directory("flipt-evaluation")).
-		WithFile("/src/Cargo.toml", hostDirectory.File("Cargo.toml"))
-
-	var err error
-
-	rust, err = rust.
-		WithExec(args("cargo install wasm-pack wasm-opt")). // Install wasm-pack
-		WithWorkdir("/src/flipt-engine-wasm-js").
-		WithExec(args("wasm-pack build --target %s", target)). // Build the wasm package
-		Sync(ctx)
-
-	if err != nil {
-		return err
+	for _, s := range builds {
+		s := s
+		g.Go(take(func() error {
+			return s.Build(ctx, client, dir, sdks.BuildOpts{
+				Push: push,
+			})
+		}))
 	}
 
-	container := client.Container().From("node:21.2-bookworm").
-		WithDirectory("/src", hostDirectory.Directory(clientDir), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{".node_modules/", ".gitignore", "pkg/", "dist/"},
-		}).
-		WithDirectory("/src/dist", rust.Directory("/src/flipt-engine-wasm-js/pkg"), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{".node_modules/", ".gitignore", "package.json", "README.md", "LICENSE"},
-		}).
-		WithWorkdir("/src").
-		WithExec(args("npm install")).  // Install dependencies
-		WithExec(args("npm run build")) // Build the package
-
-	if !push {
-		out, err := container.WithExec(args("apt-get update")).
-			WithExec(args("apt-get install -y tree")).
-			WithExec(args("tree -I node_modules /src")).
-			Stdout(ctx)
-		if err != nil {
-			return err
-		}
-		fmt.Println(out)
-		return nil
-	}
-
-	if os.Getenv("NPM_API_KEY") == "" {
-		return fmt.Errorf("NPM_API_KEY is not set")
-	}
-
-	npmAPIKeySecret := client.SetSecret("npm-api-key", os.Getenv("NPM_API_KEY"))
-
-	_, err = container.WithSecretVariable("NPM_TOKEN", npmAPIKeySecret).
-		WithExec(args("npm config set -- //registry.npmjs.org/:_authToken ${NPM_TOKEN}")).
-		WithExec(args("npm publish --access public")).
-		Sync(ctx)
-
-	return err
-}
-
-func nodeBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) error {
-	return buildWasm(ctx, client, hostDirectory, "nodejs", "flipt-client-node")
-}
-
-func browserBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) error {
-	return buildWasm(ctx, client, hostDirectory, "web", "flipt-client-browser")
+	return g.Wait()
 }

--- a/package/wasm/main.go
+++ b/package/wasm/main.go
@@ -6,17 +6,15 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime"
 	"strings"
 
 	"dagger.io/dagger"
 )
 
 var (
-	architecture string
-	sdks         string
-	push         bool
-	tag          string
+	sdks string
+	push bool
+	tag  string
 )
 
 func init() {
@@ -27,11 +25,6 @@ func init() {
 
 func main() {
 	flag.Parse()
-
-	architecture = "x86_64"
-	if strings.Contains(runtime.GOARCH, "arm64") || strings.Contains(runtime.GOARCH, "aarch64") {
-		architecture = "arm64"
-	}
 
 	if err := run(); err != nil {
 		log.Fatal(err)
@@ -68,27 +61,32 @@ func run() error {
 	return build(ctx, client, dir)
 }
 
-func nodeBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) error {
+func args(args string, a ...any) []string {
+	if len(a) == 0 {
+		return strings.Split(args, " ")
+	}
+	return strings.Split(fmt.Sprintf(args, a...), " ")
+}
+
+func buildWasm(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory, target string, clientDir string) error {
 	rust := client.Container().From("rust:1.83.0-bookworm").
 		WithWorkdir("/src").
 		WithDirectory("/src/flipt-engine-ffi", hostDirectory.Directory("flipt-engine-ffi")).
 		WithDirectory("/src/flipt-engine-wasm", hostDirectory.Directory("flipt-engine-wasm"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{"pkg/", ".gitignore"},
 		}).
+		WithDirectory("/src/flipt-engine-wasm-js", hostDirectory.Directory("flipt-engine-wasm-js"), dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{"pkg/", ".gitignore"},
+		}).
 		WithDirectory("/src/flipt-evaluation", hostDirectory.Directory("flipt-evaluation")).
 		WithFile("/src/Cargo.toml", hostDirectory.File("Cargo.toml"))
-
-	if architecture == "arm64" {
-		rust = rust.WithExec([]string{"apt-get", "update"}).
-			WithExec([]string{"apt-get", "-y", "install", "binaryen"})
-	}
 
 	var err error
 
 	rust, err = rust.
-		WithExec([]string{"cargo", "install", "wasm-pack"}). // Install wasm-pack
-		WithWorkdir("/src/flipt-engine-wasm").
-		WithExec([]string{"wasm-pack", "build", "--target", "nodejs"}). // Build the wasm package
+		WithExec(args("cargo install wasm-pack wasm-opt")). // Install wasm-pack
+		WithWorkdir("/src/flipt-engine-wasm-js").
+		WithExec(args("wasm-pack build --target %s", target)). // Build the wasm package
 		Sync(ctx)
 
 	if err != nil {
@@ -96,19 +94,26 @@ func nodeBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger
 	}
 
 	container := client.Container().From("node:21.2-bookworm").
-		WithDirectory("/src", hostDirectory.Directory("flipt-client-node"), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{".node_modules/", ".gitignore", "pkg/"},
+		WithDirectory("/src", hostDirectory.Directory(clientDir), dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{".node_modules/", ".gitignore", "pkg/", "dist/"},
 		}).
-		WithDirectory("/src/dist", rust.Directory("/src/flipt-engine-wasm/pkg"), dagger.ContainerWithDirectoryOpts{
+		WithDirectory("/src/dist", rust.Directory("/src/flipt-engine-wasm-js/pkg"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".node_modules/", ".gitignore", "package.json", "README.md", "LICENSE"},
 		}).
 		WithWorkdir("/src").
-		WithExec([]string{"npm", "install"}).     // Install dependencies
-		WithExec([]string{"npm", "run", "build"}) // Build the node package
+		WithExec(args("npm install")).  // Install dependencies
+		WithExec(args("npm run build")) // Build the package
 
 	if !push {
-		_, err = container.Sync(ctx)
-		return err
+		out, err := container.WithExec(args("apt-get update")).
+			WithExec(args("apt-get install -y tree")).
+			WithExec(args("tree -I node_modules /src")).
+			Stdout(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Println(out)
+		return nil
 	}
 
 	if os.Getenv("NPM_API_KEY") == "" {
@@ -118,66 +123,17 @@ func nodeBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger
 	npmAPIKeySecret := client.SetSecret("npm-api-key", os.Getenv("NPM_API_KEY"))
 
 	_, err = container.WithSecretVariable("NPM_TOKEN", npmAPIKeySecret).
-		WithExec([]string{"npm", "config", "set", "--", "//registry.npmjs.org/:_authToken", "${NPM_TOKEN}"}).
-		WithExec([]string{"npm", "publish", "--access", "public"}).
+		WithExec(args("npm config set -- //registry.npmjs.org/:_authToken ${NPM_TOKEN}")).
+		WithExec(args("npm publish --access public")).
 		Sync(ctx)
 
 	return err
 }
 
+func nodeBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) error {
+	return buildWasm(ctx, client, hostDirectory, "nodejs", "flipt-client-node")
+}
+
 func browserBuild(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory) error {
-	rust := client.Container().From("rust:1.83.0-bookworm").
-		WithWorkdir("/src").
-		WithDirectory("/src/flipt-engine-ffi", hostDirectory.Directory("flipt-engine-ffi")).
-		WithDirectory("/src/flipt-engine-wasm", hostDirectory.Directory("flipt-engine-wasm"), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"pkg/", ".gitignore"},
-		}).
-		WithDirectory("/src/flipt-evaluation", hostDirectory.Directory("flipt-evaluation")).
-		WithFile("/src/Cargo.toml", hostDirectory.File("Cargo.toml"))
-
-	if architecture == "arm64" {
-		rust = rust.WithExec([]string{"apt-get", "update"}).
-			WithExec([]string{"apt-get", "-y", "install", "binaryen"})
-	}
-
-	var err error
-
-	rust, err = rust.
-		WithExec([]string{"cargo", "install", "wasm-pack"}). // Install wasm-pack
-		WithWorkdir("/src/flipt-engine-wasm").
-		WithExec([]string{"wasm-pack", "build", "--target", "web"}). // Build the wasm package
-		Sync(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	container := client.Container().From("node:21.2-bookworm").
-		WithDirectory("/src", hostDirectory.Directory("flipt-client-browser"), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{".node_modules/", ".gitignore", "pkg/"},
-		}).
-		WithDirectory("/src/dist", rust.Directory("/src/flipt-engine-wasm/pkg"), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{".node_modules/", ".gitignore", "package.json", "README.md", "LICENSE"},
-		}).
-		WithWorkdir("/src").
-		WithExec([]string{"npm", "install"}).     // Install dependencies
-		WithExec([]string{"npm", "run", "build"}) // Build the browser package
-
-	if !push {
-		_, err = container.Sync(ctx)
-		return err
-	}
-
-	if os.Getenv("NPM_API_KEY") == "" {
-		return fmt.Errorf("NPM_API_KEY is not set")
-	}
-
-	npmAPIKeySecret := client.SetSecret("npm-api-key", os.Getenv("NPM_API_KEY"))
-
-	_, err = container.WithSecretVariable("NPM_TOKEN", npmAPIKeySecret).
-		WithExec([]string{"npm", "config", "set", "--", "//registry.npmjs.org/:_authToken", "${NPM_TOKEN}"}).
-		WithExec([]string{"npm", "publish", "--access", "public"}).
-		Sync(ctx)
-
-	return err
+	return buildWasm(ctx, client, hostDirectory, "web", "flipt-client-browser")
 }

--- a/package/wasm/main.go
+++ b/package/wasm/main.go
@@ -90,6 +90,7 @@ func run() error {
 		g.Go(take(func() error {
 			return s.Build(ctx, client, dir, sdks.BuildOpts{
 				Push: push,
+				Tag:  tag,
 			})
 		}))
 	}

--- a/package/wasm/sdks/browser.go
+++ b/package/wasm/sdks/browser.go
@@ -1,0 +1,15 @@
+package sdks
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+)
+
+type BrowserSDK struct {
+	BaseSDK
+}
+
+func (s *BrowserSDK) Build(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory, opts BuildOpts) error {
+	return buildWasmJS(ctx, client, hostDirectory, opts, "web", "flipt-client-browser")
+}

--- a/package/wasm/sdks/node.go
+++ b/package/wasm/sdks/node.go
@@ -1,0 +1,15 @@
+package sdks
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+)
+
+type NodeSDK struct {
+	BaseSDK
+}
+
+func (s *NodeSDK) Build(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory, opts BuildOpts) error {
+	return buildWasmJS(ctx, client, hostDirectory, opts, "nodejs", "flipt-client-node")
+}

--- a/package/wasm/sdks/sdk.go
+++ b/package/wasm/sdks/sdk.go
@@ -1,0 +1,90 @@
+package sdks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"dagger.io/dagger"
+)
+
+type BuildOpts struct {
+	Push bool
+	Tag  string
+}
+
+type SDK interface {
+	Build(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory, opts BuildOpts) error
+}
+
+type BaseSDK struct{}
+
+func buildWasmJS(ctx context.Context, client *dagger.Client, hostDirectory *dagger.Directory, opts BuildOpts, target string, clientDir string) error {
+	rust := client.Container().From("rust:1.83.0-bookworm").
+		WithWorkdir("/src").
+		WithDirectory("/src/flipt-engine-ffi", hostDirectory.Directory("flipt-engine-ffi")).
+		WithDirectory("/src/flipt-engine-wasm", hostDirectory.Directory("flipt-engine-wasm"), dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{"pkg/", ".gitignore"},
+		}).
+		WithDirectory("/src/flipt-engine-wasm-js", hostDirectory.Directory("flipt-engine-wasm-js"), dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{"pkg/", ".gitignore"},
+		}).
+		WithDirectory("/src/flipt-evaluation", hostDirectory.Directory("flipt-evaluation")).
+		WithFile("/src/Cargo.toml", hostDirectory.File("Cargo.toml"))
+
+	var err error
+
+	rust, err = rust.
+		WithExec(args("cargo install wasm-pack wasm-opt")). // Install wasm-pack
+		WithWorkdir("/src/flipt-engine-wasm-js").
+		WithExec(args("wasm-pack build --target %s", target)). // Build the wasm package
+		Sync(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	container := client.Container().From("node:21.2-bookworm").
+		WithDirectory("/src", hostDirectory.Directory(clientDir), dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{".node_modules/", ".gitignore", "pkg/", "dist/"},
+		}).
+		WithDirectory("/src/dist", rust.Directory("/src/flipt-engine-wasm-js/pkg"), dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{".node_modules/", ".gitignore", "package.json", "README.md", "LICENSE"},
+		}).
+		WithWorkdir("/src").
+		WithExec(args("npm install")).  // Install dependencies
+		WithExec(args("npm run build")) // Build the package
+
+	if !opts.Push {
+		out, err := container.WithExec(args("apt-get update")).
+			WithExec(args("apt-get install -y tree")).
+			WithExec(args("tree -I node_modules /src")).
+			Stdout(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Println(out)
+		return nil
+	}
+
+	if os.Getenv("NPM_API_KEY") == "" {
+		return fmt.Errorf("NPM_API_KEY is not set")
+	}
+
+	npmAPIKeySecret := client.SetSecret("npm-api-key", os.Getenv("NPM_API_KEY"))
+
+	_, err = container.WithSecretVariable("NPM_TOKEN", npmAPIKeySecret).
+		WithExec(args("npm config set -- //registry.npmjs.org/:_authToken ${NPM_TOKEN}")).
+		WithExec(args("npm publish --access public")).
+		Sync(ctx)
+
+	return err
+}
+
+func args(args string, a ...any) []string {
+	if len(a) == 0 {
+		return strings.Split(args, " ")
+	}
+	return strings.Split(fmt.Sprintf(args, a...), " ")
+}

--- a/test/main.go
+++ b/test/main.go
@@ -52,7 +52,9 @@ type testResult struct {
 
 const (
 	headerFile = "/src/flipt-engine-ffi/include/flipt_engine.h"
+	libDir     = "/src/target/x86_64-unknown-linux-musl/release"
 	wasmJSDir  = "/src/flipt-engine-wasm-js/pkg"
+	wasmFile   = "/src/target/wasm32-wasip1/release/flipt_engine_wasm.wasm"
 )
 
 var (
@@ -351,7 +353,7 @@ func getWasmBuildContainer(_ context.Context, client *dagger.Client, hostDirecto
 		WithExec(args("rustup target add " + target)).
 		WithExec(args("cargo build -p flipt-engine-wasm --release --target " + target)).
 		WithExec(args("cargo install wasm-opt")).
-		WithExec(args("wasm-opt --converge --flatten --rereloop -Oz -Oz --gufa -o /src/target/wasm32-wasip1/release/flipt_engine_wasm.wasm /src/target/wasm32-wasip1/release/flipt_engine_wasm.wasm"))
+		WithExec(args("wasm-opt --converge --flatten --rereloop -Oz -Oz --gufa -o %s %s", wasmFile, wasmFile))
 }
 
 // getWasmJSBuildContainer builds the wasm module for the Rust core for the client libraries to run
@@ -383,7 +385,7 @@ func pythonTests(ctx context.Context, root *dagger.Container, t *testCase) error
 		WithExec(args("pip install poetry==1.7.0")).
 		WithWorkdir("/src").
 		WithDirectory("/src", t.hostDir.Directory("flipt-client-python")).
-		WithDirectory("/src/ext/linux_x86_64", t.engine.Directory("/src/target/x86_64-unknown-linux-musl/release")).
+		WithDirectory("/src/ext/linux_x86_64", t.engine.Directory(libDir)).
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -400,7 +402,7 @@ func goTests(ctx context.Context, root *dagger.Container, t *testCase) error {
 	_, err := root.
 		WithWorkdir("/src").
 		WithDirectory("/src", t.hostDir.Directory("flipt-client-go")).
-		WithFile("/src/ext/flipt_engine_wasm.wasm", t.engine.File("/src/target/wasm32-wasip1/release/flipt_engine_wasm.wasm")).
+		WithFile("/src/ext/flipt_engine_wasm.wasm", t.engine.File(wasmFile)).
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -439,7 +441,7 @@ func rubyTests(ctx context.Context, root *dagger.Container, t *testCase) error {
 	_, err := root.
 		WithWorkdir("/src").
 		WithDirectory("/src", t.hostDir.Directory("flipt-client-ruby")).
-		WithDirectory("/src/lib/ext/linux_x86_64", t.engine.Directory("/src/target/x86_64-unknown-linux-musl/release")).
+		WithDirectory("/src/lib/ext/linux_x86_64", t.engine.Directory(libDir)).
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -458,7 +460,7 @@ func javaTests(ctx context.Context, root *dagger.Container, t *testCase) error {
 		WithDirectory("/src", t.hostDir.Directory("flipt-client-java"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{"./.idea/", ".gradle/", "build/"},
 		}).
-		WithDirectory("/src/src/main/resources/linux-x86-64", t.engine.Directory("/src/target/x86_64-unknown-linux-musl/release")).
+		WithDirectory("/src/src/main/resources/linux-x86-64", t.engine.Directory(libDir)).
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -515,7 +517,7 @@ func dartTests(ctx context.Context, root *dagger.Container, t *testCase) error {
 		WithDirectory("/src", t.hostDir.Directory("flipt-client-dart"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".gitignore", ".dart_tool/"},
 		}).
-		WithDirectory("/src/lib/src/ffi/linux_x86_64", t.engine.Directory("/src/target/x86_64-unknown-linux-musl/release")).
+		WithDirectory("/src/lib/src/ffi/linux_x86_64", t.engine.Directory(libDir)).
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").
@@ -534,7 +536,7 @@ func csharpTests(ctx context.Context, root *dagger.Container, t *testCase) error
 		WithDirectory("/src", t.hostDir.Directory("flipt-client-csharp"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".gitignore", "obj/", "bin/"},
 		}).
-		WithDirectory("/src/src/FliptClient/ext/ffi/linux_x86_64", t.engine.Directory("/src/target/x86_64-unknown-linux-musl/release")).
+		WithDirectory("/src/src/FliptClient/ext/ffi/linux_x86_64", t.engine.Directory(libDir)).
 		WithServiceBinding("flipt", t.flipt.WithExec(nil).AsService()).
 		WithEnvVariable("FLIPT_URL", "http://flipt:8080").
 		WithEnvVariable("FLIPT_AUTH_TOKEN", "secret").

--- a/test/main.go
+++ b/test/main.go
@@ -335,7 +335,7 @@ func getFFIBuildContainer(_ context.Context, client *dagger.Client, hostDirector
 func getWasmBuildContainer(_ context.Context, client *dagger.Client, hostDirectory *dagger.Directory) *dagger.Container {
 	const target = "wasm32-wasip1"
 
-	container := client.Container(dagger.ContainerOpts{
+	return client.Container(dagger.ContainerOpts{
 		Platform: dagger.Platform("linux/amd64"),
 	}).From("rust:1.83.0-bullseye").
 		WithWorkdir("/src").
@@ -349,16 +349,15 @@ func getWasmBuildContainer(_ context.Context, client *dagger.Client, hostDirecto
 		WithDirectory("/src/flipt-evaluation", hostDirectory.Directory("flipt-evaluation")).
 		WithFile("/src/Cargo.toml", hostDirectory.File("Cargo.toml")).
 		WithExec(args("rustup target add " + target)).
-		WithExec(args("cargo build -p flipt-engine-wasm --release --target " + target)) // Build the wasm module
-
-	return container.WithExec(args("cargo install wasm-opt")).
+		WithExec(args("cargo build -p flipt-engine-wasm --release --target " + target)).
+		WithExec(args("cargo install wasm-opt")).
 		WithExec(args("wasm-opt --converge --flatten --rereloop -Oz -Oz --gufa -o /src/target/wasm32-wasip1/release/flipt_engine_wasm.wasm /src/target/wasm32-wasip1/release/flipt_engine_wasm.wasm"))
 }
 
 // getWasmJSBuildContainer builds the wasm module for the Rust core for the client libraries to run
 // their tests against.
 func getWasmJSBuildContainer(_ context.Context, client *dagger.Client, hostDirectory *dagger.Directory, target string) *dagger.Container {
-	container := client.Container(dagger.ContainerOpts{
+	return client.Container(dagger.ContainerOpts{
 		Platform: dagger.Platform("linux/amd64"),
 	}).From("rust:1.83.0-bullseye").
 		WithWorkdir("/src").
@@ -371,11 +370,10 @@ func getWasmJSBuildContainer(_ context.Context, client *dagger.Client, hostDirec
 		}).
 		WithDirectory("/src/flipt-evaluation", hostDirectory.Directory("flipt-evaluation")).
 		WithFile("/src/Cargo.toml", hostDirectory.File("Cargo.toml")).
-		WithExec(args("cargo build -p flipt-engine-wasm-js --release")) // Build the wasm module
-
-	return container.WithExec(args("cargo install wasm-opt wasm-pack")). // Install wasm-pack
-										WithWorkdir("/src/flipt-engine-wasm-js").
-										WithExec(args("wasm-pack build --target " + target)) // Build the wasm package
+		WithExec(args("cargo build -p flipt-engine-wasm-js --release")).
+		WithExec(args("cargo install wasm-opt wasm-pack")).
+		WithWorkdir("/src/flipt-engine-wasm-js").
+		WithExec(args("wasm-pack build --target " + target))
 }
 
 // pythonTests runs the python integration test suite against a container running Flipt.


### PR DESCRIPTION
Redoes the packaging code to work with the changes in #747 


I tested this by adding output to stdout using the `tree` command and ensured that all the contents for each SDK are in the correct places