### PR TITLE
chore: rm uuid dependency

### DIFF
--- a/flipt-engine-wasm-js/Cargo.toml
+++ b/flipt-engine-wasm-js/Cargo.toml
@@ -16,7 +16,6 @@ wasm-bindgen = "0.2.92"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }
 serde-wasm-bindgen = "0.6.5"
-uuid = { version = "1.14.0", features = ["v4", "js"] }
 console_error_panic_hook = "0.1.7"
 chrono = { version = "0.4.31", features = ["wasmbind"] }
 

--- a/flipt-engine-wasm/Cargo.toml
+++ b/flipt-engine-wasm/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["cdylib"]
 libc = { version = "0.2.150", features = ["std"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }
-uuid = { version = "1.14.0", features = ["v4", "js"] }
 thiserror = "2.0.3"
 
 [dependencies.flipt-evaluation]

--- a/flipt-evaluation/Cargo.toml
+++ b/flipt-evaluation/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }
-uuid = { version = "1.14.0", features = ["v4"] }
 crc32fast = "1.3.2"
 thiserror = "2.0.3"
 chrono = { version = "0.4.31", features = ["serde"] }

--- a/flipt-evaluation/src/store.rs
+++ b/flipt-evaluation/src/store.rs
@@ -84,7 +84,7 @@ impl Snapshot {
                 let rule_id = format!("{}-{}", flag.key, index);
                 let mut eval_rule = flipt::EvaluationRule {
                     id: rule_id.clone(),
-                    rank: idx + 1,
+                    rank: index,
                     flag_key: flag.key.clone(),
                     segments: HashMap::new(),
                     segment_operator: rule.segment_operator,

--- a/flipt-evaluation/src/store.rs
+++ b/flipt-evaluation/src/store.rs
@@ -80,7 +80,8 @@ impl Snapshot {
             let flag_rules = flag.rules.unwrap_or(vec![]);
 
             for (idx, rule) in flag_rules.into_iter().enumerate() {
-                let rule_id = uuid::Uuid::new_v4().to_string();
+                let index = idx + 1;
+                let rule_id = format!("{}-{}", flag.key, index);
                 let mut eval_rule = flipt::EvaluationRule {
                     id: rule_id.clone(),
                     rank: idx + 1,


### PR DESCRIPTION
we dont really need uuids, we just need a string that is unique per flag/rule

this removes the uuid crate which doesn't really work on 'wasm32-unknown-unknown` anyways.. not that it really matters since we are building to `wasip1`.. but its always nice to remove dependencies