### PR TITLE
feat: Go retries

### DIFF
--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -636,7 +636,7 @@ func (e *EvaluationClient) fetch(ctx context.Context, etag string) (snapshot, er
 	var lastErr error
 	for attempt := range maxRetries {
 		if attempt > 0 {
-			// Calculate exponential backoff delay: 100ms, 200ms, 400ms
+			// calculate exponential backoff delay: 100ms, 200ms, 400ms
 			delay := baseDelay * time.Duration(1<<uint(attempt-1))
 			select {
 			case <-ctx.Done():
@@ -702,7 +702,7 @@ func (e *EvaluationClient) fetch(ctx context.Context, etag string) (snapshot, er
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			// Don't retry non-200 status codes as they are likely not transient
+			// don't retry non-200 status codes as they are likely not transient
 			return snapshot{}, fetchError(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
 		}
 
@@ -710,7 +710,7 @@ func (e *EvaluationClient) fetch(ctx context.Context, etag string) (snapshot, er
 		return snapshot{payload: body, etag: etag}, nil
 	} // end of retry loop
 
-	// If we get here, we've exhausted our retries
+	// if we get here, we've exhausted our retries
 	return snapshot{}, fetchError(fmt.Errorf("failed after %d retries, last error: %w", maxRetries, lastErr))
 }
 
@@ -739,7 +739,7 @@ func (e *EvaluationClient) initiateStream(ctx context.Context) error {
 	var lastErr error
 	for attempt := range maxRetries {
 		if attempt > 0 {
-			// Calculate exponential backoff delay: 100ms, 200ms, 400ms
+			// calculate exponential backoff delay: 100ms, 200ms, 400ms
 			delay := baseDelay * time.Duration(1<<uint(attempt-1))
 			select {
 			case <-ctx.Done():
@@ -780,7 +780,7 @@ func (e *EvaluationClient) initiateStream(ctx context.Context) error {
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			// Don't retry non-200 status codes as they are likely not transient
+			// don't retry non-200 status codes as they are likely not transient
 			return fetchError(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
 		}
 
@@ -793,7 +793,7 @@ func (e *EvaluationClient) initiateStream(ctx context.Context) error {
 		}
 	}
 
-	// If we get here, we've exhausted our retries
+	// if we get here, we've exhausted our retries
 	return fetchError(fmt.Errorf("failed after %d retries, last error: %w", maxRetries, lastErr))
 }
 
@@ -802,9 +802,9 @@ func (e *EvaluationClient) handleStream(ctx context.Context, r io.ReadCloser) er
 	readChan := make(chan struct {
 		line []byte
 		err  error
-	}, 1) // Buffered channel to prevent goroutine leak
+	}, 1) // buffered channel to prevent goroutine leak
 
-	// Start a goroutine to perform the blocking read
+	// start a goroutine to perform the blocking read
 	go func() {
 		for {
 			select {
@@ -941,25 +941,25 @@ func isTransientError(err error) bool {
 		return false
 	}
 
-	// Check for network errors
+	// check for network errors
 	var netErr net.Error
 	if errors.As(err, &netErr) {
 		return netErr.Timeout()
 	}
 
-	// Check for specific network operation errors
+	// check for specific network operation errors
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
 		return opErr.Temporary() || opErr.Timeout()
 	}
 
-	// Check for DNS temporary failures
+	// check for DNS temporary failures
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
 		return dnsErr.Temporary()
 	}
 
-	// Some errors are always considered temporary
+	// some errors are always considered temporary
 	if errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -102,7 +102,7 @@ func (s *EvaluationTestSuite) TestBatch() {
 	s.Len(batch.Responses, 3)
 
 	variant := batch.Responses[0]
-	s.Equal("VARIANT_EVALUATION_RESPONSE_TYPE", variant.Type)
+	s.Require().Equal("VARIANT_EVALUATION_RESPONSE_TYPE", variant.Type)
 	s.True(variant.VariantEvaluationResponse.Match)
 	s.Equal("flag1", variant.VariantEvaluationResponse.FlagKey)
 	s.Equal("MATCH_EVALUATION_REASON", variant.VariantEvaluationResponse.Reason)

--- a/flipt-client-go/evaluation_test.go
+++ b/flipt-client-go/evaluation_test.go
@@ -5,67 +5,76 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	flipt "go.flipt.io/flipt-client"
 )
 
-var (
-	evaluationClient *flipt.EvaluationClient
-	fliptUrl         string
-	authToken        string
-)
+type EvaluationTestSuite struct {
+	suite.Suite
+	client    *flipt.EvaluationClient
+	fliptURL  string
+	authToken string
+}
 
-func init() {
+func TestEvaluationSuite(t *testing.T) {
+	suite.Run(t, new(EvaluationTestSuite))
+}
+
+func (s *EvaluationTestSuite) SetupSuite() {
 	opts := []flipt.ClientOption{}
 
 	if os.Getenv("FLIPT_URL") != "" {
-		fliptUrl = os.Getenv("FLIPT_URL")
-		opts = append(opts, flipt.WithURL(fliptUrl))
+		s.fliptURL = os.Getenv("FLIPT_URL")
+		opts = append(opts, flipt.WithURL(s.fliptURL))
 	}
 
 	if os.Getenv("FLIPT_AUTH_TOKEN") != "" {
-		authToken = os.Getenv("FLIPT_AUTH_TOKEN")
-		opts = append(opts, flipt.WithClientTokenAuthentication(authToken))
+		s.authToken = os.Getenv("FLIPT_AUTH_TOKEN")
+		opts = append(opts, flipt.WithClientTokenAuthentication(s.authToken))
 	}
 
 	var err error
-	evaluationClient, err = flipt.NewEvaluationClient(context.TODO(), opts...)
-	if err != nil {
-		panic(err)
-	}
+	s.client, err = flipt.NewEvaluationClient(context.TODO(), opts...)
+	require.NoError(s.T(), err)
 }
 
-func TestInvalidAuthentication(t *testing.T) {
-	_, err := flipt.NewEvaluationClient(context.TODO(), flipt.WithURL(fliptUrl), flipt.WithClientTokenAuthentication("invalid"))
-	assert.EqualError(t, err, "failed to fetch initial state: unexpected status code: 401")
+func (s *EvaluationTestSuite) TearDownSuite() {
+	s.client.Close(context.TODO())
 }
 
-func TestVariant(t *testing.T) {
-	variant, err := evaluationClient.EvaluateVariant(context.TODO(), "flag1", "someentity", map[string]string{
+func (s *EvaluationTestSuite) TestInvalidAuthentication() {
+	_, err := flipt.NewEvaluationClient(context.TODO(),
+		flipt.WithURL(s.fliptURL),
+		flipt.WithClientTokenAuthentication("invalid"))
+	s.EqualError(err, "failed to fetch initial state: unexpected status code: 401")
+}
+
+func (s *EvaluationTestSuite) TestVariant() {
+	variant, err := s.client.EvaluateVariant(context.TODO(), "flag1", "someentity", map[string]string{
 		"fizz": "buzz",
 	})
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
-	assert.True(t, variant.Match)
-	assert.Equal(t, "flag1", variant.FlagKey)
-	assert.Equal(t, "MATCH_EVALUATION_REASON", variant.Reason)
-	assert.Contains(t, variant.SegmentKeys, "segment1")
+	s.True(variant.Match)
+	s.Equal("flag1", variant.FlagKey)
+	s.Equal("MATCH_EVALUATION_REASON", variant.Reason)
+	s.Contains(variant.SegmentKeys, "segment1")
 }
 
-func TestBoolean(t *testing.T) {
-	boolean, err := evaluationClient.EvaluateBoolean(context.TODO(), "flag_boolean", "someentity", map[string]string{
+func (s *EvaluationTestSuite) TestBoolean() {
+	boolean, err := s.client.EvaluateBoolean(context.TODO(), "flag_boolean", "someentity", map[string]string{
 		"fizz": "buzz",
 	})
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
-	assert.Equal(t, "flag_boolean", boolean.FlagKey)
-	assert.True(t, boolean.Enabled)
-	assert.Equal(t, "MATCH_EVALUATION_REASON", boolean.Reason)
+	s.Equal("flag_boolean", boolean.FlagKey)
+	s.True(boolean.Enabled)
+	s.Equal("MATCH_EVALUATION_REASON", boolean.Reason)
 }
 
-func TestBatch(t *testing.T) {
-	batch, err := evaluationClient.EvaluateBatch(context.TODO(), []*flipt.EvaluationRequest{
+func (s *EvaluationTestSuite) TestBatch() {
+	batch, err := s.client.EvaluateBatch(context.TODO(), []*flipt.EvaluationRequest{
 		{
 			FlagKey:  "flag1",
 			EntityId: "someentity",
@@ -88,48 +97,48 @@ func TestBatch(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
-	assert.Len(t, batch.Responses, 3)
+	s.Len(batch.Responses, 3)
 
 	variant := batch.Responses[0]
-	assert.Equal(t, "VARIANT_EVALUATION_RESPONSE_TYPE", variant.Type)
-	assert.True(t, variant.VariantEvaluationResponse.Match)
-	assert.Equal(t, "flag1", variant.VariantEvaluationResponse.FlagKey)
-	assert.Equal(t, "MATCH_EVALUATION_REASON", variant.VariantEvaluationResponse.Reason)
-	assert.Contains(t, variant.VariantEvaluationResponse.SegmentKeys, "segment1")
+	s.Equal("VARIANT_EVALUATION_RESPONSE_TYPE", variant.Type)
+	s.True(variant.VariantEvaluationResponse.Match)
+	s.Equal("flag1", variant.VariantEvaluationResponse.FlagKey)
+	s.Equal("MATCH_EVALUATION_REASON", variant.VariantEvaluationResponse.Reason)
+	s.Contains(variant.VariantEvaluationResponse.SegmentKeys, "segment1")
 
 	boolean := batch.Responses[1]
-	assert.Equal(t, "BOOLEAN_EVALUATION_RESPONSE_TYPE", boolean.Type)
-	assert.Equal(t, "flag_boolean", boolean.BooleanEvaluationResponse.FlagKey)
-	assert.True(t, boolean.BooleanEvaluationResponse.Enabled)
-	assert.Equal(t, "MATCH_EVALUATION_REASON", boolean.BooleanEvaluationResponse.Reason)
+	s.Equal("BOOLEAN_EVALUATION_RESPONSE_TYPE", boolean.Type)
+	s.Equal("flag_boolean", boolean.BooleanEvaluationResponse.FlagKey)
+	s.True(boolean.BooleanEvaluationResponse.Enabled)
+	s.Equal("MATCH_EVALUATION_REASON", boolean.BooleanEvaluationResponse.Reason)
 
 	errorResponse := batch.Responses[2]
-	assert.Equal(t, "ERROR_EVALUATION_RESPONSE_TYPE", errorResponse.Type)
-	assert.Equal(t, "notfound", errorResponse.ErrorEvaluationResponse.FlagKey)
-	assert.Equal(t, "default", errorResponse.ErrorEvaluationResponse.NamespaceKey)
-	assert.Equal(t, "NOT_FOUND_ERROR_EVALUATION_REASON", errorResponse.ErrorEvaluationResponse.Reason)
+	s.Equal("ERROR_EVALUATION_RESPONSE_TYPE", errorResponse.Type)
+	s.Equal("notfound", errorResponse.ErrorEvaluationResponse.FlagKey)
+	s.Equal("default", errorResponse.ErrorEvaluationResponse.NamespaceKey)
+	s.Equal("NOT_FOUND_ERROR_EVALUATION_REASON", errorResponse.ErrorEvaluationResponse.Reason)
 }
 
-func TestListFlags(t *testing.T) {
-	response, err := evaluationClient.ListFlags(context.TODO())
-	require.NoError(t, err)
+func (s *EvaluationTestSuite) TestListFlags() {
+	response, err := s.client.ListFlags(context.TODO())
+	s.Require().NoError(err)
 
-	assert.NotEmpty(t, response)
-	assert.Equal(t, 2, len(response))
+	s.NotEmpty(response)
+	s.Equal(2, len(response))
 }
 
-func TestVariantFailure(t *testing.T) {
-	_, err := evaluationClient.EvaluateVariant(context.TODO(), "nonexistent", "someentity", map[string]string{
+func (s *EvaluationTestSuite) TestVariantFailure() {
+	_, err := s.client.EvaluateVariant(context.TODO(), "nonexistent", "someentity", map[string]string{
 		"fizz": "buzz",
 	})
-	assert.EqualError(t, err, "invalid request: failed to get flag information default/nonexistent")
+	s.EqualError(err, "invalid request: failed to get flag information default/nonexistent")
 }
 
-func TestBooleanFailure(t *testing.T) {
-	_, err := evaluationClient.EvaluateBoolean(context.TODO(), "nonexistent", "someentity", map[string]string{
+func (s *EvaluationTestSuite) TestBooleanFailure() {
+	_, err := s.client.EvaluateBoolean(context.TODO(), "nonexistent", "someentity", map[string]string{
 		"fizz": "buzz",
 	})
-	assert.EqualError(t, err, "invalid request: failed to get flag information default/nonexistent")
+	s.EqualError(err, "invalid request: failed to get flag information default/nonexistent")
 }

--- a/flipt-client-go/models.go
+++ b/flipt-client-go/models.go
@@ -28,15 +28,6 @@ const (
 	ErrorStrategyFallback ErrorStrategy = "fallback"
 )
 
-type clientOptions[T any] struct {
-	URL            string        `json:"url,omitempty"`
-	Authentication *T            `json:"authentication,omitempty"`
-	UpdateInterval int           `json:"update_interval,omitempty"`
-	Reference      string        `json:"reference,omitempty"`
-	FetchMode      FetchMode     `json:"fetch_mode,omitempty"`
-	ErrorStrategy  ErrorStrategy `json:"error_strategy,omitempty"`
-}
-
 type Flag struct {
 	Key     string `json:"key"`
 	Enabled bool   `json:"enabled"`


### PR DESCRIPTION
Fixes: #755 

- Adds retries for fetch and initiating streaming (currently 3x) with jitter
- Changes to build the URLs in the constructor, instead of each fetch call