### PR TITLE
feat: make retries more consistent across Go and FFI impl

### DIFF
--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.11"
 
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/flipt-client-csharp/README.md
+++ b/flipt-client-csharp/README.md
@@ -32,6 +32,20 @@ By default, the SDK will poll the Flipt server for new flag state at a regular i
 
 When in streaming mode, the SDK will connect to the Flipt server and open a persistent connection that will remain open until the client is closed. The SDK will then receive flag state changes in real-time.
 
+### Retries
+
+The SDK will automatically retry fetching (or initiating streaming) flag state if the client is unable to reach the Flipt server temporarily.
+
+The SDK will retry up to 3 times with an exponential backoff interval between retries. The base delay is 1 second and the maximum delay is 30 seconds.
+
+Retriable errors include:
+
+- `429 Too Many Requests`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+- Other potential transient network or DNS errors
+
 ## Supported Architectures
 
 This SDK currently supports the following OSes/architectures:

--- a/flipt-client-dart/README.md
+++ b/flipt-client-dart/README.md
@@ -37,6 +37,20 @@ By default, the SDK will poll the Flipt server for new flag state at a regular i
 
 When in streaming mode, the SDK will connect to the Flipt server and open a persistent connection that will remain open until the client is closed. The SDK will then receive flag state changes in real-time.
 
+### Retries
+
+The SDK will automatically retry fetching (or initiating streaming) flag state if the client is unable to reach the Flipt server temporarily.
+
+The SDK will retry up to 3 times with an exponential backoff interval between retries. The base delay is 1 second and the maximum delay is 30 seconds.
+
+Retriable errors include:
+
+- `429 Too Many Requests`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+- Other potential transient network or DNS errors
+
 ## Supported Architectures
 
 This SDK currently supports the following OSes/architectures:

--- a/flipt-client-go/README.md
+++ b/flipt-client-go/README.md
@@ -35,6 +35,20 @@ By default, the SDK will poll the Flipt server for new flag state at a regular i
 
 When in streaming mode, the SDK will connect to the Flipt server and open a persistent connection that will remain open until the client is closed. The SDK will then receive flag state changes in real-time.
 
+### Retries
+
+The SDK will automatically retry fetching (or initiating streaming) flag state if the client is unable to reach the Flipt server temporarily.
+
+The SDK will retry up to 3 times with an exponential backoff interval between retries. The base delay is 1 second and the maximum delay is 30 seconds.
+
+Retriable errors include:
+
+- `429 Too Many Requests`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+- Other potential transient network or DNS errors
+
 ## Supported Architectures
 
 This SDK currently supports the following OSes/architectures:

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -148,6 +148,9 @@ type fetchError struct {
 }
 
 func (e fetchError) Error() string {
+	if e.err == nil {
+		return fmt.Sprintf("fetch error: %d", e.code)
+	}
 	return e.err.Error()
 }
 

--- a/flipt-client-java/README.md
+++ b/flipt-client-java/README.md
@@ -50,6 +50,20 @@ By default, the SDK will poll the Flipt server for new flag state at a regular i
 
 When in streaming mode, the SDK will connect to the Flipt server and open a persistent connection that will remain open until the client is closed. The SDK will then receive flag state changes in real-time.
 
+### Retries
+
+The SDK will automatically retry fetching (or initiating streaming) flag state if the client is unable to reach the Flipt server temporarily.
+
+The SDK will retry up to 3 times with an exponential backoff interval between retries. The base delay is 1 second and the maximum delay is 30 seconds.
+
+Retriable errors include:
+
+- `429 Too Many Requests`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+- Other potential transient network or DNS errors
+
 ## Supported Architectures
 
 This SDK currently supports the following OSes/architectures:

--- a/flipt-client-kotlin-android/README.md
+++ b/flipt-client-kotlin-android/README.md
@@ -50,6 +50,20 @@ By default, the SDK will poll the Flipt server for new flag state at a regular i
 
 When in streaming mode, the SDK will connect to the Flipt server and open a persistent connection that will remain open until the client is closed. The SDK will then receive flag state changes in real-time.
 
+### Retries
+
+The SDK will automatically retry fetching (or initiating streaming) flag state if the client is unable to reach the Flipt server temporarily.
+
+The SDK will retry up to 3 times with an exponential backoff interval between retries. The base delay is 1 second and the maximum delay is 30 seconds.
+
+Retriable errors include:
+
+- `429 Too Many Requests`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+- Other potential transient network or DNS errors
+
 ## Supported Architectures
 
 This SDK currently supports the following OSes/architectures:

--- a/flipt-client-python/README.md
+++ b/flipt-client-python/README.md
@@ -32,6 +32,20 @@ By default, the SDK will poll the Flipt server for new flag state at a regular i
 
 When in streaming mode, the SDK will connect to the Flipt server and open a persistent connection that will remain open until the client is closed. The SDK will then receive flag state changes in real-time.
 
+### Retries
+
+The SDK will automatically retry fetching (or initiating streaming) flag state if the client is unable to reach the Flipt server temporarily.
+
+The SDK will retry up to 3 times with an exponential backoff interval between retries. The base delay is 1 second and the maximum delay is 30 seconds.
+
+Retriable errors include:
+
+- `429 Too Many Requests`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+- Other potential transient network or DNS errors
+
 ## Supported Architectures
 
 This SDK currently supports the following OSes/architectures:

--- a/flipt-client-ruby/README.md
+++ b/flipt-client-ruby/README.md
@@ -32,6 +32,20 @@ By default, the SDK will poll the Flipt server for new flag state at a regular i
 
 When in streaming mode, the SDK will connect to the Flipt server and open a persistent connection that will remain open until the client is closed. The SDK will then receive flag state changes in real-time.
 
+### Retries
+
+The SDK will automatically retry fetching (or initiating streaming) flag state if the client is unable to reach the Flipt server temporarily.
+
+The SDK will retry up to 3 times with an exponential backoff interval between retries. The base delay is 1 second and the maximum delay is 30 seconds.
+
+Retriable errors include:
+
+- `429 Too Many Requests`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+- Other potential transient network or DNS errors
+
 ## Supported Architectures
 
 This SDK currently supports the following OSes/architectures:

--- a/flipt-client-swift/README.md
+++ b/flipt-client-swift/README.md
@@ -17,6 +17,7 @@ dependencies: [
 ```
 
 Or add it directly through Xcode:
+
 1. File > Add Package Dependencies
 2. Enter package URL: `https://github.com/flipt-io/flipt-client-swift`
 
@@ -41,6 +42,20 @@ By default, the SDK will poll the Flipt server for new flag state at a regular i
 [Flipt Cloud](https://flipt.io/cloud) users can use the `streaming` fetch method to stream flag state changes from the Flipt server to the SDK.
 
 When in streaming mode, the SDK will connect to the Flipt server and open a persistent connection that will remain open until the client is closed. The SDK will then receive flag state changes in real-time.
+
+### Retries
+
+The SDK will automatically retry fetching (or initiating streaming) flag state if the client is unable to reach the Flipt server temporarily.
+
+The SDK will retry up to 3 times with an exponential backoff interval between retries. The base delay is 1 second and the maximum delay is 30 seconds.
+
+Retriable errors include:
+
+- `429 Too Many Requests`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+- Other potential transient network or DNS errors
 
 ## Supported Platforms
 

--- a/flipt-engine-ffi/src/http.rs
+++ b/flipt-engine-ffi/src/http.rs
@@ -8,7 +8,7 @@ use reqwest::header::{self, HeaderMap};
 use reqwest::Response;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::policies::ExponentialBackoff;
-use reqwest_retry::RetryTransientMiddleware;
+use reqwest_retry::{Jitter, RetryTransientMiddleware};
 use serde::Deserialize;
 use tokio::sync::mpsc;
 use tokio_util::io::StreamReader;
@@ -153,7 +153,11 @@ impl HTTPFetcherBuilder {
     }
 
     pub fn build(self) -> HTTPFetcher {
-        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+        let retry_policy = ExponentialBackoff::builder()
+            .retry_bounds(Duration::from_secs(1), Duration::from_secs(30))
+            .jitter(Jitter::Full)
+            .build_with_max_retries(3);
+
         HTTPFetcher {
             base_url: self.base_url,
             namespace: self.namespace,


### PR DESCRIPTION
This makes the retry functionality more consistent between Go and the FFI SDKs by:

1. Making min retry delay 1s
2. Making max retry delay 30s
3. Make exponential backoff consistent (2s, 4s, 8s) (note we never get to 30s with only 3 retries)
4. Adding Jitter to the rust impl
5. Handling certain transient HTTP statuses in the Go impl

Also adds retry info to the readmes of clients that implement it

---

This pull request includes several changes to improve the retry mechanism across multiple SDKs and the Go client. The most important changes include adding retry documentation to various SDK README files, modifying the retry logic in the Go client, and updating the HTTP retry policy in the Rust FFI.

Documentation updates:
* [`flipt-client-csharp/README.md`](diffhunk://#diff-a59842282a5e722b46ab29b15397e964927f76a9b37feb0019f39837a29928f1R35-R48): Added a section on retries, explaining the automatic retry mechanism with exponential backoff and listing retriable errors.
* [`flipt-client-dart/README.md`](diffhunk://#diff-99093903e32d81e85b00fa0791ba5126390ddc3ab9b799b22fee2a0789fb44f9R40-R53): Added a section on retries, explaining the automatic retry mechanism with exponential backoff and listing retriable errors.
* [`flipt-client-go/README.md`](diffhunk://#diff-ed038b150fe5db512f3144dc66eafc37b878b857b7fde7d1061d84575710912dR38-R51): Added a section on retries, explaining the automatic retry mechanism with exponential backoff and listing retriable errors.
* Similar retry sections were added to the README files of `flipt-client-java`, `flipt-client-kotlin-android`, `flipt-client-python`, `flipt-client-ruby`, and `flipt-client-swift`. [[1]](diffhunk://#diff-34d4e336de8c309442bc70520ada30ae0b436bd5a89f0109a171d43b6decdd47R53-R66) [[2]](diffhunk://#diff-4707739b7dbcf541ec14091da2a3897f676710e021a698796ee5cc27a0ae2b70R53-R66) [[3]](diffhunk://#diff-7d47f2e72d6374ed25b52e90f1091e829c5c55cd15266bf9136bb897712da17cR35-R48) [[4]](diffhunk://#diff-7820982a39b559e6422bcdb7e2085244516fb69e9ba7eb8d9537e7b606892bb7R35-R48) [[5]](diffhunk://#diff-c06d3654a10765e65dcf5f60c6895e66e455023cad4e5ffaeba77daa659502aaR46-R59)

Go client retry logic:
* [`flipt-client-go/evaluation.go`](diffhunk://#diff-58b9ecc6b9da5261cb8f7e750248a80ddb464de80acf087070cdcc59f0f47e93L145-R152): Introduced a new `fetchError` struct to encapsulate error codes and messages. Updated the retry logic to handle specific HTTP status codes as transient errors. Adjusted the base and maximum delay for retries to 1 second and 30 seconds, respectively. [[1]](diffhunk://#diff-58b9ecc6b9da5261cb8f7e750248a80ddb464de80acf087070cdcc59f0f47e93L145-R152) [[2]](diffhunk://#diff-58b9ecc6b9da5261cb8f7e750248a80ddb464de80acf087070cdcc59f0f47e93L640-R648) [[3]](diffhunk://#diff-58b9ecc6b9da5261cb8f7e750248a80ddb464de80acf087070cdcc59f0f47e93L655-R662) [[4]](diffhunk://#diff-58b9ecc6b9da5261cb8f7e750248a80ddb464de80acf087070cdcc59f0f47e93L736-R743) [[5]](diffhunk://#diff-58b9ecc6b9da5261cb8f7e750248a80ddb464de80acf087070cdcc59f0f47e93L785-R791) [[6]](diffhunk://#diff-58b9ecc6b9da5261cb8f7e750248a80ddb464de80acf087070cdcc59f0f47e93L841-R846) [[7]](diffhunk://#diff-58b9ecc6b9da5261cb8f7e750248a80ddb464de80acf087070cdcc59f0f47e93R950-R961)

Rust FFI retry policy:
* [`flipt-engine-ffi/src/http.rs`](diffhunk://#diff-6359428840197529ae955aa2f01f26aeceb050844e822b92407043df2350c9afL11-R11): Updated the retry policy to include jitter and set retry bounds to 1 second and 30 seconds. [[1]](diffhunk://#diff-6359428840197529ae955aa2f01f26aeceb050844e822b92407043df2350c9afL11-R11) [[2]](diffhunk://#diff-6359428840197529ae955aa2f01f26aeceb050844e822b92407043df2350c9afL156-R160)