### PR TITLE
feat: allow passing http timeout to rust engine for polling

### DIFF
--- a/flipt-client-go/README.md
+++ b/flipt-client-go/README.md
@@ -100,6 +100,7 @@ The `NewClient` constructor accepts a variadic number of `ClientOption` function
 
 - `WithNamespace`: The namespace to fetch flag state from. If not provided, the client will default to the `default` namespace.
 - `WithURL`: The URL of the upstream Flipt instance. If not provided, the client will default to `http://localhost:8080`.
+- `WithRequestTimeout`: The timeout (in seconds) for total request time to the upstream Flipt instance. If not provided, the client will default to no timeout. Note: this only affects polling mode. Streaming mode will have no timeout set.
 - `WithUpdateInterval`: The interval (in seconds) in which to fetch new flag state. If not provided, the client will default to 120 seconds.
 - `With{Method}Authentication`: The authentication strategy to use when communicating with the upstream Flipt instance. If not provided, the client will default to no authentication. See the [Authentication](#authentication) section for more information.
 - `WithReference`: The [reference](https://docs.flipt.io/guides/user/using-references) to use when fetching flag state. If not provided, reference will not be used.

--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-engine-ffi"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"

--- a/flipt-engine-ffi/examples/evaluation.rs
+++ b/flipt-engine-ffi/examples/evaluation.rs
@@ -11,7 +11,9 @@ fn main() {
     let namespace = "default";
     let fetcher = HTTPFetcherBuilder::new("http://localhost:8080", namespace)
         .authentication(Authentication::with_client_token("secret".into()))
-        .build();
+        .build()
+        .unwrap();
+
     let evaluator = Evaluator::new(namespace);
 
     let engine = fliptengine::Engine::new(namespace, fetcher, evaluator, ErrorStrategy::Fail);

--- a/flipt-evaluation/Cargo.toml
+++ b/flipt-evaluation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-evaluation"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"

--- a/flipt-evaluation/src/error.rs
+++ b/flipt-evaluation/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     InvalidRequest(String),
     #[error("server error: {0}")]
     Server(String),
+    #[error("internal error: {0}")]
+    Internal(String),
     #[error("unknown error: {0}")]
     Unknown(String),
 }


### PR DESCRIPTION
re: #738 

Adds a `request_timeout` option to the http client builder and lib ffi engine opts so that the wrapping SDKs can provide an [overall timeout](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout) for the entire request (only for polling mode).

This should match the `request_timeout` option we have in the [Go SDK](https://github.com/flipt-io/flipt-client-sdks/blob/6452a250f90d2decc68869863e6f6b88503c1266/flipt-client-go/evaluation.go#L139)

Also sets the user-agent header in FFI engine requests to the current engine version (ex: `flipt-engine-ffi/0.6.0`)

And adds a new `Internal` error to the evaluation lib

## TODO (other PRs)

- [ ] add request_timeout option to native SDKs