### PR TITLE
chore: More linters

### DIFF
--- a/.github/workflows/lint-sdks.yml
+++ b/.github/workflows/lint-sdks.yml
@@ -31,26 +31,21 @@ jobs:
   lint-typescript:
     name: Lint Typescript
     strategy:
+      fail-fast: false
       matrix:
-        node-version: ["20", "21"]
+        sdk: ["flipt-client-node", "flipt-client-browser", "flipt-client-react"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
 
-      - name: Install Node ${{ matrix.node-version }}
+      - name: Install Node 21
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 21
 
-      - name: Lint Typescript source for flipt-client-node
-        working-directory: flipt-client-node
-        run: |
-          npm ci
-          npm run lint
-
-      - name: Lint Typescript source for flipt-client-react
-        working-directory: flipt-client-react
+      - name: Lint Typescript source for ${{ matrix.sdk }}
+        working-directory: ${{ matrix.sdk }}
         run: |
           npm ci
           npm run lint
@@ -93,3 +88,95 @@ jobs:
           gem install bundler
           bundle install
           bundle exec rubocop
+
+  lint-csharp:
+    name: Lint C#
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        working-directory: flipt-client-csharp
+        run: dotnet restore
+
+      - name: Check formatting
+        working-directory: flipt-client-csharp
+        run: dotnet format style --verify-no-changes --verbosity detailed
+
+      - name: Build with analyzers
+        working-directory: flipt-client-csharp
+        run: dotnet build --no-restore /warnaserror
+
+  lint-kotlin:
+    name: Lint Kotlin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Lint Kotlin code
+        working-directory: flipt-client-kotlin-android
+        run: |
+          chmod +x ./gradlew
+          ./gradlew ktlintFormat --continue
+          ./gradlew ktlintCheck
+
+  lint-go:
+    name: Lint Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: false
+
+      # Touch the wasm file to ensure it is present at lint time
+      - name: Touch wasm file
+        working-directory: flipt-client-go
+        run: touch ext/flipt_engine_wasm.wasm
+
+      - name: Lint Go code
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: flipt-client-go
+          args: --timeout=5m
+          version: v1.64
+
+  lint-swift:
+    name: Lint Swift
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Install SwiftLint and SwiftFormat
+        run: |
+          brew install swiftlint
+          brew install swiftformat
+
+      - name: Check Swift formatting
+        working-directory: flipt-client-swift
+        run: swiftformat . --lint
+
+      - name: Lint Swift code
+        working-directory: flipt-client-swift
+        run: swiftlint lint --strict

--- a/flipt-client-browser/package-lock.json
+++ b/flipt-client-browser/package-lock.json
@@ -13,6 +13,7 @@
         "@rollup/plugin-wasm": "^6.2.2",
         "@types/jest": "^29.5.12",
         "jest": "^29.7.0",
+        "prettier": "^3.1.0",
         "rollup": "^4.14.0",
         "tslib": "^2.6.2",
         "typescript": "^5.4.3",
@@ -4144,6 +4145,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/flipt-client-browser/package.json
+++ b/flipt-client-browser/package.json
@@ -34,6 +34,7 @@
     "rollup": "^4.14.0",
     "tslib": "^2.6.2",
     "typescript": "^5.4.3",
-    "undici": "^7.1.0"
+    "undici": "^7.1.0",
+    "prettier": "^3.1.0"
   }
 }

--- a/flipt-client-csharp/src/FliptClient/EvaluationClient.cs
+++ b/flipt-client-csharp/src/FliptClient/EvaluationClient.cs
@@ -16,16 +16,18 @@ namespace FliptClient
             _engine = NativeMethods.InitializeEngine(@namespace, optsJson);
         }
 
-        public VariantEvaluationResponse EvaluateVariant(string flagKey, string entityId, Dictionary<string, string> context)
+        public VariantEvaluationResponse? EvaluateVariant(string flagKey, string entityId, Dictionary<string, string> context)
         {
             if (string.IsNullOrWhiteSpace(flagKey))
             {
                 throw new ArgumentException("flagKey cannot be empty or null");
             }
+
             if (string.IsNullOrWhiteSpace(entityId))
             {
                 throw new ArgumentException("entityId cannot be empty or null");
             }
+
             if (context == null)
             {
                 context = new Dictionary<string, string>();
@@ -40,28 +42,30 @@ namespace FliptClient
 
             string requestJson = JsonSerializer.Serialize(request);
             IntPtr resultPtr = NativeMethods.EvaluateVariant(_engine, requestJson);
-            string resultJson = Marshal.PtrToStringAnsi(resultPtr);
+            string resultJson = Marshal.PtrToStringAnsi(resultPtr) ?? throw new InvalidOperationException("Failed to get result from native code");
             NativeMethods.DestroyString(resultPtr);
 
-            var result = JsonSerializer.Deserialize<VariantResult>(resultJson);
+            var result = JsonSerializer.Deserialize<VariantResult>(resultJson) ?? throw new InvalidOperationException("Failed to deserialize response");
             if (result.Status != "success")
             {
-                throw new Exception(result.ErrorMessage);
+                throw new Exception(result.ErrorMessage ?? "Unknown error");
             }
 
             return result.Response;
         }
 
-        public BooleanEvaluationResponse EvaluateBoolean(string flagKey, string entityId, Dictionary<string, string> context)
+        public BooleanEvaluationResponse? EvaluateBoolean(string flagKey, string entityId, Dictionary<string, string> context)
         {
             if (string.IsNullOrWhiteSpace(flagKey))
             {
                 throw new ArgumentException("flagKey cannot be empty or null");
             }
+
             if (string.IsNullOrWhiteSpace(entityId))
             {
                 throw new ArgumentException("entityId cannot be empty or null");
             }
+
             if (context == null)
             {
                 context = new Dictionary<string, string>();
@@ -76,19 +80,19 @@ namespace FliptClient
 
             string requestJson = JsonSerializer.Serialize(request);
             IntPtr resultPtr = NativeMethods.EvaluateBoolean(_engine, requestJson);
-            string resultJson = Marshal.PtrToStringAnsi(resultPtr);
+            string resultJson = Marshal.PtrToStringAnsi(resultPtr) ?? throw new InvalidOperationException("Failed to get result from native code");
             NativeMethods.DestroyString(resultPtr);
 
-            var result = JsonSerializer.Deserialize<BooleanResult>(resultJson);
+            var result = JsonSerializer.Deserialize<BooleanResult>(resultJson) ?? throw new InvalidOperationException("Failed to deserialize response");
             if (result.Status != "success")
             {
-                throw new Exception(result.ErrorMessage);
+                throw new Exception(result.ErrorMessage ?? "Unknown error");
             }
 
             return result.Response;
         }
 
-        public BatchEvaluationResponse EvaluateBatch(List<EvaluationRequest> requests)
+        public BatchEvaluationResponse? EvaluateBatch(List<EvaluationRequest> requests)
         {
             if (requests == null || requests.Count == 0)
             {
@@ -97,28 +101,28 @@ namespace FliptClient
 
             string requestJson = JsonSerializer.Serialize(requests);
             IntPtr resultPtr = NativeMethods.EvaluateBatch(_engine, requestJson);
-            string resultJson = Marshal.PtrToStringAnsi(resultPtr);
+            string resultJson = Marshal.PtrToStringAnsi(resultPtr) ?? throw new InvalidOperationException("Failed to get result from native code");
             NativeMethods.DestroyString(resultPtr);
 
-            var result = JsonSerializer.Deserialize<BatchResult>(resultJson);
+            var result = JsonSerializer.Deserialize<BatchResult>(resultJson) ?? throw new InvalidOperationException("Failed to deserialize response");
             if (result.Status != "success")
             {
-                throw new Exception(result.ErrorMessage);
+                throw new Exception(result.ErrorMessage ?? "Unknown error");
             }
 
             return result.Response;
         }
 
-        public Flag[] ListFlags()
+        public Flag[]? ListFlags()
         {
             IntPtr resultPtr = NativeMethods.ListFlags(_engine);
-            string resultJson = Marshal.PtrToStringAnsi(resultPtr);
+            string resultJson = Marshal.PtrToStringAnsi(resultPtr) ?? throw new InvalidOperationException("Failed to get result from native code");
             NativeMethods.DestroyString(resultPtr);
 
-            var result = JsonSerializer.Deserialize<ListFlagsResult>(resultJson);
+            var result = JsonSerializer.Deserialize<ListFlagsResult>(resultJson) ?? throw new InvalidOperationException("Failed to deserialize response");
             if (result.Status != "success")
             {
-                throw new Exception(result.ErrorMessage);
+                throw new Exception(result.ErrorMessage ?? "Unknown error");
             }
 
             return result.Response;

--- a/flipt-client-csharp/src/FliptClient/FliptClient.csproj
+++ b/flipt-client-csharp/src/FliptClient/FliptClient.csproj
@@ -21,6 +21,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)StyleCop.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
     <Content Include="ext/ffi/windows_x86_64/fliptengine.dll" Condition="Exists('ext/ffi/windows_x86_64/fliptengine.dll')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Pack>true</Pack>

--- a/flipt-client-csharp/src/FliptClient/Models/ClientOptions.cs
+++ b/flipt-client-csharp/src/FliptClient/Models/ClientOptions.cs
@@ -60,8 +60,8 @@ namespace FliptClient.Models
         public string? JwtToken { get; set; }
     }
 
-
-    public class LowercaseEnumConverter<T> : JsonConverter<T> where T : struct, Enum
+    public class LowercaseEnumConverter<T> : JsonConverter<T>
+        where T : struct, Enum
     {
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
@@ -70,6 +70,7 @@ namespace FliptClient.Models
             {
                 return value;
             }
+
             throw new JsonException($"Unable to convert \"{enumString}\" to {typeof(T)}.");
         }
 

--- a/flipt-client-csharp/src/FliptClient/Models/Request.cs
+++ b/flipt-client-csharp/src/FliptClient/Models/Request.cs
@@ -1,17 +1,15 @@
 using System.Text.Json.Serialization;
 
-namespace FliptClient.Models
+namespace FliptClient;
+
+public class EvaluationRequest
 {
-    public class EvaluationRequest
-    {
-        [JsonPropertyName("flag_key")]
-        public string FlagKey { get; set; }
+    [JsonPropertyName("flag_key")]
+    public required string FlagKey { get; set; }
 
-        [JsonPropertyName("entity_id")]
-        public string EntityId { get; set; }
+    [JsonPropertyName("entity_id")]
+    public required string EntityId { get; set; }
 
-        [JsonPropertyName("context")]
-        public Dictionary<string, string> Context { get; set; }
-    }
+    [JsonPropertyName("context")]
+    public required Dictionary<string, string> Context { get; set; }
 }
-

--- a/flipt-client-csharp/src/FliptClient/Models/Response.cs
+++ b/flipt-client-csharp/src/FliptClient/Models/Response.cs
@@ -1,107 +1,124 @@
 using System.Text.Json.Serialization;
 
-namespace FliptClient.Models
+namespace FliptClient;
+
+public class Flag
 {
-    public class Flag
-    {
-        [JsonPropertyName("key")]
-        public string Key { get; set; }
+    [JsonPropertyName("key")]
+    public required string Key { get; set; }
 
-        [JsonPropertyName("enabled")]
-        public bool Enabled { get; set; }
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
 
-        [JsonPropertyName("type")]
-        public string Type { get; set; }
-    }
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
+}
 
-    public class VariantEvaluationResponse
-    {
-        [JsonPropertyName("flag_key")]
-        public string FlagKey { get; set; }
+public class VariantEvaluationResponse
+{
+    [JsonPropertyName("flag_key")]
+    public required string FlagKey { get; set; }
 
-        [JsonPropertyName("match")]
-        public bool Match { get; set; }
+    [JsonPropertyName("match")]
+    public bool Match { get; set; }
 
-        [JsonPropertyName("segment_keys")]
-        public string[] SegmentKeys { get; set; }
+    [JsonPropertyName("segment_keys")]
+    public required List<string> SegmentKeys { get; set; }
 
-        [JsonPropertyName("reason")]
-        public string Reason { get; set; }
+    [JsonPropertyName("reason")]
+    public required string Reason { get; set; }
 
-        [JsonPropertyName("variant_key")]
-        public string VariantKey { get; set; }
+    [JsonPropertyName("variant_key")]
+    public required string VariantKey { get; set; }
 
-        [JsonPropertyName("variant_attachment")]
-        public string? VariantAttachment { get; set; }
-    }
+    [JsonPropertyName("variant_attachment")]
+    public string? VariantAttachment { get; set; }
 
-    public class BooleanEvaluationResponse
-    {
-        [JsonPropertyName("flag_key")]
-        public string FlagKey { get; set; }
+    [JsonPropertyName("request_duration_millis")]
+    public double RequestDurationMillis { get; set; }
 
-        [JsonPropertyName("enabled")]
-        public bool Enabled { get; set; }
+    [JsonPropertyName("timestamp")]
+    public string? Timestamp { get; set; }
+}
 
-        [JsonPropertyName("reason")]
-        public string Reason { get; set; }
-    }
+public class BooleanEvaluationResponse
+{
+    [JsonPropertyName("flag_key")]
+    public required string FlagKey { get; set; }
 
-    public class BatchEvaluationResponse
-    {
-        [JsonPropertyName("request_id")]
-        public string RequestId { get; set; }
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
 
-        [JsonPropertyName("responses")]
-        public Response[] Responses { get; set; }
+    [JsonPropertyName("reason")]
+    public required string Reason { get; set; }
 
-        [JsonPropertyName("request_duration_millis")]
-        public float RequestDurationMillis { get; set; }
-    }
+    [JsonPropertyName("request_duration_millis")]
+    public double RequestDurationMillis { get; set; }
 
+    [JsonPropertyName("timestamp")]
+    public string? Timestamp { get; set; }
+}
 
-    public class Response
-    {
-        [JsonPropertyName("type")]
-        public string Type { get; set; }
+public class BatchEvaluationResponse
+{
+    [JsonPropertyName("responses")]
+    public required List<Response> Responses { get; set; }
 
-        [JsonPropertyName("boolean_evaluation_response")]
-        public BooleanEvaluationResponse? BooleanEvaluationResponse { get; set; }
+    [JsonPropertyName("request_duration_millis")]
+    public double RequestDurationMillis { get; set; }
+}
 
-        [JsonPropertyName("variant_evaluation_response")]
-        public VariantEvaluationResponse? VariantEvaluationResponse { get; set; }
+public class Response
+{
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
 
-        [JsonPropertyName("error_evaluation_response")]
-        public ErrorEvaluationResponse? ErrorEvaluationResponse { get; set; }
-    }
+    [JsonPropertyName("boolean_evaluation_response")]
+    public BooleanEvaluationResponse? BooleanEvaluationResponse { get; set; }
 
+    [JsonPropertyName("variant_evaluation_response")]
+    public VariantEvaluationResponse? VariantEvaluationResponse { get; set; }
 
-    public class ErrorEvaluationResponse
-    {
-        [JsonPropertyName("flag_key")]
-        public string? FlagKey { get; set; }
+    [JsonPropertyName("error_evaluation_response")]
+    public ErrorEvaluationResponse? ErrorEvaluationResponse { get; set; }
+}
 
-        [JsonPropertyName("namespace_key")]
-        public string? NamespaceKey { get; set; }
+public class ErrorEvaluationResponse
+{
+    [JsonPropertyName("flag_key")]
+    public required string FlagKey { get; set; }
 
-        [JsonPropertyName("reason")]
-        public string? Reason { get; set; }
-    }
+    [JsonPropertyName("namespace_key")]
+    public required string NamespaceKey { get; set; }
 
-    public class Result<T>
-    {
-        [JsonPropertyName("status")]
-        public string Status { get; set; }
+    [JsonPropertyName("reason")]
+    public required string Reason { get; set; }
+}
 
-        [JsonPropertyName("result")]
-        public T? Response { get; set; }
+public class Result<T>
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; set; }
 
-        [JsonPropertyName("error_message")]
-        public string? ErrorMessage { get; set; }
-    }
+    [JsonPropertyName("result")]
+    public T? Response { get; set; }
 
-    public class VariantResult : Result<VariantEvaluationResponse> { }
-    public class BooleanResult : Result<BooleanEvaluationResponse> { }
-    public class BatchResult : Result<BatchEvaluationResponse> { }
-    public class ListFlagsResult : Result<Flag[]> { }
+    [JsonPropertyName("error_message")]
+    public string? ErrorMessage { get; set; }
+}
+
+public class VariantResult : Result<VariantEvaluationResponse>
+{
+}
+
+public class BooleanResult : Result<BooleanEvaluationResponse>
+{
+}
+
+public class BatchResult : Result<BatchEvaluationResponse>
+{
+}
+
+public class ListFlagsResult : Result<Flag[]>
+{
 }

--- a/flipt-client-csharp/src/FliptClient/NativeMethods.cs
+++ b/flipt-client-csharp/src/FliptClient/NativeMethods.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Runtime.InteropServices;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace FliptClient
 {
@@ -74,6 +75,7 @@ namespace FliptClient
             {
                 return directPath;
             }
+
             if (File.Exists(runtimePath))
             {
                 return runtimePath;
@@ -84,7 +86,7 @@ namespace FliptClient
 
         private static string GetPlatformLibraryPath()
         {
-            string libraryPath = "";
+            string libraryPath = string.Empty;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -116,7 +118,8 @@ namespace FliptClient
             return libraryPath;
         }
 
-        private static T GetDelegate<T>(string functionName) where T : Delegate
+        private static T GetDelegate<T>(string functionName)
+            where T : Delegate
         {
             if (_nativeLibraryHandle == IntPtr.Zero)
             {
@@ -130,6 +133,18 @@ namespace FliptClient
             }
 
             return Marshal.GetDelegateForFunctionPointer<T>(procAddress);
+        }
+
+        private static string GetString(IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            var str = Marshal.PtrToStringUTF8(ptr);
+            DestroyString(ptr);
+            return str ?? string.Empty;
         }
     }
 }

--- a/flipt-client-csharp/src/FliptClient/StyleCop.ruleset
+++ b/flipt-client-csharp/src/FliptClient/StyleCop.ruleset
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="StyleCop rules for Flipt Client" Description="StyleCop rules for Flipt Client" ToolsVersion="14.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- Documentation Rules -->
+    <Rule Id="SA0001" Action="None" /> <!-- XML comment analysis disabled -->
+    <Rule Id="SA1600" Action="None" /> <!-- Elements should be documented -->
+    <Rule Id="SA1601" Action="Warning" /> <!-- Partial elements should be documented -->
+    <Rule Id="SA1602" Action="Warning" /> <!-- Enumeration items should be documented -->
+    <Rule Id="SA1633" Action="None" /> <!-- File should have header -->
+    <Rule Id="SA1649" Action="None" /> <!-- File name should match first type name -->
+
+    <!-- Layout Rules -->
+    <Rule Id="SA1500" Action="Warning" /> <!-- Braces for multi-line statements -->
+    <Rule Id="SA1501" Action="Warning" /> <!-- Statement should not be on a single line -->
+    <Rule Id="SA1502" Action="Warning" /> <!-- Element should not be on a single line -->
+    <Rule Id="SA1516" Action="None" /> <!-- Elements should be separated by blank line -->
+
+    <!-- Ordering Rules -->
+    <Rule Id="SA1201" Action="None" /> <!-- Elements should appear in the correct order -->
+    <Rule Id="SA1202" Action="Warning" /> <!-- Elements should be ordered by access -->
+    <Rule Id="SA1203" Action="Warning" /> <!-- Constants should appear before fields -->
+    <Rule Id="SA1204" Action="Warning" /> <!-- Static elements should appear before instance elements -->
+
+    <!-- Naming Rules -->
+    <Rule Id="SA1300" Action="Warning" /> <!-- Element should begin with upper-case letter -->
+    <Rule Id="SA1309" Action="None" /> <!-- Field names should not begin with underscore -->
+
+    <!-- Maintainability Rules -->
+    <Rule Id="SA1400" Action="Warning" /> <!-- Access modifier should be declared -->
+    <Rule Id="SA1401" Action="None" /> <!-- Fields should be private -->
+    <Rule Id="SA1402" Action="None" /> <!-- File may only contain a single type -->
+    <Rule Id="SA1413" Action="None" /> <!-- Use trailing comma in multi-line initializers -->
+
+    <!-- Layout Rules -->
+    <Rule Id="SA1101" Action="None" /> <!-- Prefix local calls with this -->
+    <Rule Id="SA1200" Action="None" /> <!-- Using directives should be placed within namespace -->
+  </Rules>
+</RuleSet> 

--- a/flipt-client-csharp/src/FliptClient/stylecop.json
+++ b/flipt-client-csharp/src/FliptClient/stylecop.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Flipt Software Inc.",
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.",
+      "documentInterfaces": true,
+      "documentExposedElements": true,
+      "documentInternalElements": false,
+      "documentPrivateElements": false,
+      "documentPrivateFields": false
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace",
+      "elementOrder": [
+        "kind",
+        "constant",
+        "accessibility",
+        "static",
+        "readonly"
+      ]
+    },
+    "namingRules": {
+      "allowCommonHungarianPrefixes": true
+    },
+    "maintainabilityRules": {
+      "topLevelTypes": [
+        "class",
+        "interface",
+        "struct",
+        "enum"
+      ]
+    }
+  }
+} 

--- a/flipt-client-kotlin-android/build.gradle
+++ b/flipt-client-kotlin-android/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.serialization'
     id 'maven-publish'
     id 'signing'
+    id "org.jlleitschuh.gradle.ktlint" version "12.1.0"
 }
 
 group = 'io.flipt'

--- a/flipt-client-kotlin-android/src/main/java/io/flipt/client/FliptEvaluationClient.kt
+++ b/flipt-client-kotlin-android/src/main/java/io/flipt/client/FliptEvaluationClient.kt
@@ -37,7 +37,7 @@ class FliptEvaluationClient(namespace: String, options: ClientOptions) {
         private var reference: String? = null
         private var requestTimeout: Duration? = null
         private var updateInterval: Duration? = null
-        private var fetchMode = FetchMode.polling
+        private var fetchMode = FetchMode.POLLING
         private var errorStrategy = ErrorStrategy.FAIL
 
         /**

--- a/flipt-client-kotlin-android/src/main/java/io/flipt/client/models/FetchMode.kt
+++ b/flipt-client-kotlin-android/src/main/java/io/flipt/client/models/FetchMode.kt
@@ -1,6 +1,12 @@
 package io.flipt.client.models
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 enum class FetchMode {
-    polling,
-    streaming
+    @SerialName("polling")
+    POLLING,
+
+    @SerialName("streaming")
+    STREAMING
 }

--- a/flipt-client-swift/.swiftformat
+++ b/flipt-client-swift/.swiftformat
@@ -1,0 +1,18 @@
+--swiftversion 5.9
+--indent 4
+--maxwidth 120
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--closingparen same-line
+--commas inline
+--trimwhitespace always
+--stripunusedargs closure-only
+--self remove
+--importgrouping alphabetized
+--header strip
+--organizetypes class,enum,struct,extension,protocol
+--extensionacl on-declarations
+--allman false
+
+--exclude .build,Package.swift 

--- a/flipt-client-swift/.swiftlint.yml
+++ b/flipt-client-swift/.swiftlint.yml
@@ -1,0 +1,63 @@
+included:
+  - Sources
+  - Tests
+
+excluded:
+  - .build
+  - Package.swift
+
+opt_in_rules:
+  - empty_count
+  - empty_string
+  - force_unwrapping
+  - implicitly_unwrapped_optional
+  - legacy_random
+  - let_var_whitespace
+  - multiline_parameters
+  - operator_usage_whitespace
+  - overridden_super_call
+  - private_outlet
+  - prohibited_super_call
+  - redundant_nil_coalescing
+  - sorted_imports
+  - toggle_bool
+  - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+
+disabled_rules:
+  - trailing_whitespace
+  - line_length
+  - opening_brace
+
+identifier_name:
+  min_length: 2
+  allowed_symbols: ["_"]
+  validates_start_with_lowercase:
+    error: true
+  excluded:
+    - id
+    - up
+    - x
+    - y
+
+type_name:
+  min_length: 3
+  max_length: 50
+
+function_parameter_count:
+  warning: 6
+  error: 8
+
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+
+file_length:
+  warning: 500
+  error: 1000
+
+type_body_length:
+  warning: 300
+  error: 500 


### PR DESCRIPTION
Add more linters for:

- Go
- Kotlin
- C#
- Swift

And fixing linter issues

Note: there are potential breaking changes in the C# SDK, mainly changing some fields to required/nullable as well as some arrays into Lists.. however as we are pre-1.0 there I think it is acceptable in the pursuit of more idiomatic code.