### PR TITLE
chore: use nexus publish plugin to autorelease java/android

### DIFF
--- a/flipt-client-java/build.gradle
+++ b/flipt-client-java/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "com.diffplug.spotless" version "7.0.2"
+    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 }
 
 group = 'io.flipt'
@@ -100,4 +101,21 @@ signing {
     def signingPassphrase = System.getenv('PGP_PASSPHRASE')
     useInMemoryPgpKeys(signingKey, signingPassphrase)
     sign publishing.publications.maven
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = System.getenv("MAVEN_USERNAME")
+            password = System.getenv("MAVEN_PASSWORD")
+            packageGroup = "io.flipt"
+        }
+    }
+    // Enable auto-release
+    transitionCheckOptions {
+        maxRetries.set(60)  // Number of times to retry
+        delayBetween.set(java.time.Duration.ofSeconds(10))  // Time between retries
+    }
 }

--- a/flipt-client-kotlin-android/build.gradle
+++ b/flipt-client-kotlin-android/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "org.jlleitschuh.gradle.ktlint" version "12.1.0"
+    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 }
 
 group = 'io.flipt'
@@ -123,4 +124,21 @@ signing {
     def signingPassphrase = System.getenv('PGP_PASSPHRASE')
     useInMemoryPgpKeys(signingKey, signingPassphrase)
     sign publishing.publications.maven
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = System.getenv("MAVEN_USERNAME")
+            password = System.getenv("MAVEN_PASSWORD")
+            packageGroup = "io.flipt"
+        }
+    }
+    // Enable auto-release
+    transitionCheckOptions {
+        maxRetries.set(60)  // Number of times to retry
+        delayBetween.set(java.time.Duration.ofSeconds(10))  // Time between retries
+    }
 }

--- a/package/ffi/sdks/android.go
+++ b/package/ffi/sdks/android.go
@@ -145,7 +145,7 @@ func (s *AndroidSDK) Build(ctx context.Context, client *dagger.Client, container
 		WithSecretVariable("MAVEN_PUBLISH_REGISTRY_URL", mavenRegistryUrl).
 		WithSecretVariable("PGP_PRIVATE_KEY", pgpPrivateKey).
 		WithSecretVariable("PGP_PASSPHRASE", pgpPassphrase).
-		WithExec(args("gradle publish")).
+		WithExec(args("gradle publishToSonatype closeAndReleaseSonatypeStagingRepository")).
 		Sync(ctx)
 
 	return err

--- a/package/ffi/sdks/java.go
+++ b/package/ffi/sdks/java.go
@@ -131,7 +131,7 @@ func (s *JavaSDK) Build(ctx context.Context, client *dagger.Client, container *d
 		WithSecretVariable("MAVEN_PUBLISH_REGISTRY_URL", mavenRegistryUrl).
 		WithSecretVariable("PGP_PRIVATE_KEY", pgpPrivateKey).
 		WithSecretVariable("PGP_PASSPHRASE", pgpPassphrase).
-		WithExec(args("gradle publish")).
+		WithExec(args("gradle publishToSonatype closeAndReleaseSonatypeStagingRepository")).
 		Sync(ctx)
 
 	return err


### PR DESCRIPTION
this _should_ make it so when we publish the java and android SDKs that I no longer have to login to Sonatype and manually close and release the packages (as I sometimes forget)