### PR TITLE
fix(go): client streaming url

### DIFF
--- a/.github/workflows/lint-sdks.yml
+++ b/.github/workflows/lint-sdks.yml
@@ -154,7 +154,7 @@ jobs:
         run: touch ext/flipt_engine_wasm.wasm
 
       - name: Lint Go code
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v6
         with:
           working-directory: flipt-client-go
           args: --timeout=5m

--- a/flipt-client-go/evaluation.go
+++ b/flipt-client-go/evaluation.go
@@ -41,7 +41,7 @@ const (
 
 	// API paths
 	snapshotPath  = "/internal/v1/evaluation/snapshot/namespace/%s"
-	streamingPath = "/internal/v1/evaluation/snapshots"
+	streamingPath = "/internal/v1/evaluation/snapshots?[]namespaces=%s"
 )
 
 // EvaluationClient wraps the functionality of evaluating Flipt feature flags.
@@ -986,11 +986,7 @@ func (c *EvaluationClient) getSnapshotURL() string {
 	switch c.fetchMode {
 	case FetchModeStreaming:
 		// Streaming uses a different endpoint that accepts multiple namespaces
-		url := c.baseURL + streamingPath + "?[]namespaces=" + c.namespace
-		if c.ref != "" {
-			url += "&reference=" + c.ref
-		}
-		return url
+		return fmt.Sprintf(c.baseURL+streamingPath, c.namespace)
 	case FetchModePolling:
 		// Polling uses the single namespace snapshot endpoint
 		url := fmt.Sprintf(c.baseURL+snapshotPath, c.namespace)

--- a/flipt-client-go/version.go
+++ b/flipt-client-go/version.go
@@ -1,0 +1,3 @@
+package evaluation
+
+const Version = "0.16.0"

--- a/release/sdks/go.py
+++ b/release/sdks/go.py
@@ -1,4 +1,22 @@
 from .base import TagBasedSDK
+import os
+import re
 
 class GoSDK(TagBasedSDK):
-    pass
+  def get_current_version(self) -> str:
+    return super().get_current_version()
+
+  def update_version(self, new_version: str):
+    version_file = os.path.join(self.path, "version.go")
+    with open(version_file, "r") as f:
+      data = f.read()
+
+    # Use regex to ensure we only replace the version string
+    pattern = r'const Version = "(.*?)"'
+    if not re.search(pattern, data):
+      raise ValueError(f"Could not find version string in {version_file}")
+
+    updated_data = re.sub(pattern, f'const Version = "{new_version}"', data)
+
+    with open(version_file, "w") as f:
+      f.write(updated_data)


### PR DESCRIPTION
there were a couple issues with the Go SDK, particularly when used with streaming mode

1. we set the wrong URL for the initial fetch
2. we weren't handling buffered responses like we can get from cloudflare
3. we weren't shutting down correctly, causing the waitgroup in Close to always block

Also made a few improvements:

1. set the user agent header (TODO: automate incrementing of version number in `version.go` on release)
2. don't check engine initialization on each method call, only in `NewEvaluationClient`