### PR TITLE
chore: bump wasm-bindgen to remove console log warning

### DIFF
--- a/flipt-engine-wasm-js/Cargo.toml
+++ b/flipt-engine-wasm-js/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/flipt-io/flipt-client-sdks"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.92"
+wasm-bindgen = "0.2.100"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }
 serde-wasm-bindgen = "0.6.5"


### PR DESCRIPTION
re: https://github.com/rustwasm/wasm-bindgen/issues/4122

it also seems that dependabot is not working with our cargo dependencies :(

looking at [dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-) it seems they only support cargo v1, whereas we are using v2

also could be an issue with us using cargo workspaces.. but we are defining the version dependencies in the child crates so idk