### PR TITLE
chore: FlagType enum for Python SDK

### DIFF
--- a/flipt-client-python/flipt_client/models.py
+++ b/flipt-client-python/flipt_client/models.py
@@ -1,6 +1,7 @@
 from enum import Enum
-from pydantic import BaseModel, RootModel
 from typing import List, Optional
+
+from pydantic import BaseModel, RootModel
 
 
 class EvaluationRequest(BaseModel):
@@ -30,6 +31,11 @@ class FetchMode(Enum):
 class ErrorStrategy(Enum):
     FAIL = "fail"
     FALLBACK = "fallback"
+
+
+class FlagType(str, Enum):
+    BOOLEAN = "BOOLEAN_FLAG_TYPE"
+    VARIANT = "VARIANT_FLAG_TYPE"
 
 
 class ClientOptions(BaseModel):
@@ -100,7 +106,8 @@ class BatchResult(BaseModel):
 class Flag(BaseModel):
     key: str
     enabled: bool
-    type: str
+    type: FlagType
+    description: Optional[str] = None
 
 
 class FlagList(RootModel):

--- a/flipt-client-python/tests/__init__.py
+++ b/flipt-client-python/tests/__init__.py
@@ -1,10 +1,12 @@
 import os
 import unittest
+
 from flipt_client import FliptEvaluationClient
 from flipt_client.models import (
-    ClientTokenAuthentication,
     ClientOptions,
+    ClientTokenAuthentication,
     EvaluationRequest,
+    FlagType,
 )
 
 
@@ -66,6 +68,12 @@ class TestFliptEvaluationClient(unittest.TestCase):
     def test_list_flags(self):
         flags = self.flipt_client.list_flags()
         self.assertEqual(2, len(flags))
+        for flag in flags:
+            self.assertEqual(flag.description, "flag description")
+            if flag.key == "flag1":
+                self.assertEqual(flag.type, FlagType.VARIANT)
+            elif flag.key == "flag_boolean":
+                self.assertEqual(flag.type, FlagType.BOOLEAN)
 
     def test_batch(self):
         batch = self.flipt_client.evaluate_batch(

--- a/flipt-client-ruby/spec/client_spec.rb
+++ b/flipt-client-ruby/spec/client_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Flipt::EvaluationClient do
       resp = @client.list_flags
 
       expect(resp).to_not be_nil
-      expect(resp).to include({ 'description' => '', 'enabled' => true, 'key' => 'flag_boolean', 'type' => 'BOOLEAN_FLAG_TYPE' })
+      expect(resp).to include({ 'description' => 'flag description', 'enabled' => true, 'key' => 'flag_boolean', 'type' => 'BOOLEAN_FLAG_TYPE' })
     end
   end
 end

--- a/test/fixtures/testdata/features.yml
+++ b/test/fixtures/testdata/features.yml
@@ -4,6 +4,7 @@ flags:
     name: flag1
     type: VARIANT_FLAG_TYPE
     enabled: true
+    description: flag description
     variants:
       - key: variant1
         name: variant1
@@ -17,6 +18,7 @@ flags:
     name: flag_boolean
     type: BOOLEAN_FLAG_TYPE
     enabled: true
+    description: flag description
     rollouts:
       - segment:
           key: segment1


### PR DESCRIPTION
This update introduces a `FlagType` enum to represent the `type` field of the `Flag` class in the Python SDK. It enhances clarity and allows easier validation of key types returned by the `list_flags` API.