### PR TITLE
chore: package ios engine for use in dart

### DIFF
--- a/.github/workflows/package-ffi-engine-ios.yml
+++ b/.github/workflows/package-ffi-engine-ios.yml
@@ -22,21 +22,55 @@ jobs:
           private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
           installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
 
-      - name: Download Artifact (iOS arm64)
-        uses: actions/download-artifact@v4
+      - name: Get Release Asset URL (iOS arm64)
+        id: get_asset_url_arm64
+        uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          name: flipt-engine-ffi-iOS-aarch64.tar.gz
-          path: /tmp
-          run-id: ${{ github.event.workflow_run.id }}
+          script: |
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.repos.listReleaseAssets({
+              owner,
+              repo,
+              release_id: '${{ inputs.tag }}'
+            });
+            const asset = data.find(asset => asset.name === 'flipt-engine-ffi-iOS-aarch64.tar.gz');
+            if (!asset) {
+              throw new Error('Asset not found');
+            }
+            core.setOutput('url', asset.url);
 
-      - name: Download Artifact (iOS arm64 sim)
-        uses: actions/download-artifact@v4
+      - name: Get Release Asset URL (iOS arm64 sim)
+        id: get_asset_url_arm64_sim
+        uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          name: flipt-engine-ffi-iOS-aarch64-sim.tar.gz
-          path: /tmp
-          run-id: ${{ github.event.workflow_run.id }}
+          script: |
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.repos.listReleaseAssets({
+              owner,
+              repo,
+              release_id: '${{ inputs.tag }}'
+            });
+            const asset = data.find(asset => asset.name === 'flipt-engine-ffi-iOS-aarch64-sim.tar.gz');
+            if (!asset) {
+              throw new Error('Asset not found');
+            }
+            core.setOutput('url', asset.url);
+
+      - name: Download Asset (iOS arm64)
+        run: |
+          curl -L \
+            -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" \
+            -H "Accept: application/octet-stream" \
+            "${{ steps.get_asset_url_arm64.outputs.url }}" \
+            -o /tmp/flipt-engine-ffi-iOS-aarch64.tar.gz
+
+      - name: Download Asset (iOS arm64 sim)
+        run: |
+          curl -L \
+            -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" \
+            -H "Accept: application/octet-stream" \
+            "${{ steps.get_asset_url_arm64_sim.outputs.url }}" \
+            -o /tmp/flipt-engine-ffi-iOS-aarch64-sim.tar.gz
 
       - name: Extract Artifacts
         run: |

--- a/.github/workflows/package-ffi-engine-ios.yml
+++ b/.github/workflows/package-ffi-engine-ios.yml
@@ -1,0 +1,80 @@
+name: Package FFI Engine (iOS)
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
+      - name: Download Artifact (iOS arm64)
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          name: flipt-engine-ffi-iOS-aarch64.tar.gz
+          path: /tmp
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download Artifact (iOS arm64 sim)
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          name: flipt-engine-ffi-iOS-aarch64-sim.tar.gz
+          path: /tmp
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract Artifacts
+        run: |
+          mkdir -p /tmp/flipt-engine-ffi-iOS-aarch64
+          mkdir -p /tmp/flipt-engine-ffi-iOS-aarch64-sim
+
+          tar -xzvf /tmp/flipt-engine-ffi-iOS-aarch64.tar.gz -C /tmp/flipt-engine-ffi-iOS-aarch64
+          tar -xzvf /tmp/flipt-engine-ffi-iOS-aarch64-sim.tar.gz -C /tmp/flipt-engine-ffi-iOS-aarch64-sim
+
+      - name: Move Artifacts
+        run: |
+          mkdir -p build/xcframework/ios-arm64/Headers
+          mkdir -p build/xcframework/ios-arm64-simulator/Headers
+
+          mv /tmp/flipt-engine-ffi-iOS-aarch64/target/aarch64-apple-ios/release/libfliptengine.a \
+             build/xcframework/ios-arm64/
+          mv /tmp/flipt-engine-ffi-iOS-aarch64-sim/target/aarch64-apple-ios-sim/release/libfliptengine.a \
+             build/xcframework/ios-arm64-simulator/
+
+          for platform in ios-arm64 ios-arm64-simulator; do
+            cp flipt-engine-ffi/include/flipt_engine.h build/xcframework/${platform}/Headers/
+            cp flipt-engine-ffi/include/module.modulemap build/xcframework/${platform}/Headers/
+          done
+
+      - name: Xcode Build
+        run: |
+          mkdir -p tmp/Sources
+
+          xcodebuild -create-xcframework \
+            -library "build/xcframework/ios-arm64/libfliptengine.a" \
+            -headers "build/xcframework/ios-arm64/Headers" \
+            -library "build/xcframework/ios-arm64-simulator/libfliptengine.a" \
+            -headers "build/xcframework/ios-arm64-simulator/Headers" \
+            -output "tmp/Sources/FliptEngineFFI.xcframework"
+
+      - name: Upload Release Assets (Tag)
+        uses: softprops/action-gh-release@v2
+        if: startsWith(inputs.tag, 'flipt-engine-ffi-v')
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: tmp/Sources/FliptEngineFFI.xcframework


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the packaging of the FFI engine for iOS. The workflow includes steps to fetch release assets, process them into an `xcframework`, and upload the resulting framework as a release asset.

### New GitHub Actions Workflow for iOS FFI Packaging:

* **Workflow Name and Trigger**:
  - Added a new workflow named "Package FFI Engine (iOS)" that can be triggered manually via `workflow_dispatch`. It requires a `tag` input to specify the release. (`.github/workflows/package-ffi-engine-ios.yml`)

* **Token Generation**:
  - Integrated the `tibdex/github-app-token` action to generate a GitHub App token using secrets for authentication. (`.github/workflows/package-ffi-engine-ios.yml`)

* **Release Asset Handling**:
  - Added steps to fetch URLs for specific release assets (`flipt-engine-ffi-iOS-aarch64.tar.gz` and `flipt-engine-ffi-iOS-aarch64-sim.tar.gz`) using the `actions/github-script` action. These assets are downloaded and extracted. (`.github/workflows/package-ffi-engine-ios.yml`)

* **`xcframework` Creation**:
  - Implemented steps to move the extracted artifacts into appropriate directories, add headers, and use `xcodebuild