### PR TITLE
chore: strip the ios .a libs before dart publish

### DIFF
--- a/.github/workflows/package-ffi-engine-darwin.yml
+++ b/.github/workflows/package-ffi-engine-darwin.yml
@@ -52,8 +52,13 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.platform.target }} --package flipt-engine-ffi
 
-      - name: Strip
+      - name: Strip dylib
+        if: contains(matrix.platform.target, 'darwin')
         run: strip -x target/${{ matrix.platform.target }}/release/libfliptengine.dylib
+
+      - name: Strip static library
+        if: contains(matrix.platform.target, 'ios')
+        run: strip -x target/${{ matrix.platform.target }}/release/libfliptengine.a
 
       - name: Package
         run: |

--- a/package/ffi/sdks/dart.go
+++ b/package/ffi/sdks/dart.go
@@ -109,6 +109,19 @@ func (s *DartSDK) Build(ctx context.Context, client *dagger.Client, container *d
 		}
 	}
 
+	// run strip_xcframework.sh
+	// this is because the XCFramework is not stripped and is too large to upload to pub.dev
+	// TODO: we should do this when we build the XCFramework in Actions but for now this is a quick fix
+	// TODO: also we should see if we can optimize the size of the .a files when building the Rust FFI libraries for iOS
+	cmd := exec.Command("/bin/bash", "strip_xcframework.sh")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running strip_xcframework.sh: %w", err)
+	}
+
 	include := []string{"**/FliptEngineFFI.xcframework/**"}
 	include = append(include, dynamicInclude...)
 

--- a/strip_xcframework.sh
+++ b/strip_xcframework.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Exit on error
+set -eou pipefail
+
+# Path to the original XCFramework
+XCFRAMEWORK_PATH="staging/ios/FliptEngineFFI.xcframework"
+
+# Path for the stripped version
+STRIPPED_PATH="staging/ios/FliptEngineFFI_stripped.xcframework"
+
+# Create output directory structure
+mkdir -p "$STRIPPED_PATH/ios-arm64/Headers"
+mkdir -p "$STRIPPED_PATH/ios-arm64-simulator/Headers"
+
+# Copy Info.plist
+cp "$XCFRAMEWORK_PATH/Info.plist" "$STRIPPED_PATH/"
+
+# Copy headers
+cp "$XCFRAMEWORK_PATH/ios-arm64/Headers/"* "$STRIPPED_PATH/ios-arm64/Headers/"
+cp "$XCFRAMEWORK_PATH/ios-arm64-simulator/Headers/"* "$STRIPPED_PATH/ios-arm64-simulator/Headers/"
+
+# Strip the libraries
+echo "Stripping device library..."
+strip -x "$XCFRAMEWORK_PATH/ios-arm64/libfliptengine.a" -o "$STRIPPED_PATH/ios-arm64/libfliptengine.a"
+
+echo "Stripping simulator library..."
+strip -x "$XCFRAMEWORK_PATH/ios-arm64-simulator/libfliptengine.a" -o "$STRIPPED_PATH/ios-arm64-simulator/libfliptengine.a"
+
+# Print file size comparison
+echo "Original sizes:"
+ls -lh "$XCFRAMEWORK_PATH/ios-arm64/libfliptengine.a" "$XCFRAMEWORK_PATH/ios-arm64-simulator/libfliptengine.a"
+
+echo "Stripped sizes:"
+ls -lh "$STRIPPED_PATH/ios-arm64/libfliptengine.a" "$STRIPPED_PATH/ios-arm64-simulator/libfliptengine.a"
+
+mv $STRIPPED_PATH $XCFRAMEWORK_PATH
+
+echo "Done! Stripped XCFramework is at $XCFRAMEWORK_PATH"


### PR DESCRIPTION
This is to get around this error on dart publish: https://github.com/flipt-io/flipt-client-sdks/actions/runs/14742115179/job/41382300626#step:7:3573

This removed like 12MB from the uncompressed package which should hopefully let us get under the 100MB limit

![CleanShot 2025-04-29 at 20 00 46@2x](https://github.com/user-attachments/assets/8c4d158a-7428-4c0b-9f04-ec4efa8e1fde)


This strips the .a files for iOS before adding them to the dart library. I put some TODOs in there as this is a temporary fix as we should:

1. strip them in the package-ios action before adding to the release
2. see if we can produce smaller .a files from the rust lib builds

