### PR TITLE
fix(js): rm path alias

### DIFF
--- a/flipt-client-js/src/browser/index.ts
+++ b/flipt-client-js/src/browser/index.ts
@@ -1,10 +1,10 @@
 import init, { Engine } from '../wasm/flipt_engine_wasm_js.js';
 import wasm from '../wasm/flipt_engine_wasm_js_bg.wasm';
-import { BaseFliptClient } from '~/core/base';
-import { ClientOptions, ErrorStrategy } from '~/core/types';
+import { BaseFliptClient } from '../core/base';
+import { ClientOptions, ErrorStrategy } from '../core/types';
 
-export * from '~/core/types';
-export * from '~/core/base';
+export * from '../core/types';
+export * from '../core/base';
 
 export class FliptClient extends BaseFliptClient {
   /**

--- a/flipt-client-js/src/node/index.ts
+++ b/flipt-client-js/src/node/index.ts
@@ -1,10 +1,10 @@
 import init, { Engine } from '../wasm/flipt_engine_wasm_js.js';
 import wasm from '../wasm/flipt_engine_wasm_js_bg.wasm';
-import { BaseFliptClient } from '~/core/base';
-import { ClientOptions, ErrorStrategy } from '~/core/types';
+import { BaseFliptClient } from '../core/base';
+import { ClientOptions, ErrorStrategy } from '../core/types';
 
-export * from '~/core/types';
-export * from '~/core/base';
+export * from '../core/types';
+export * from '../core/base';
 
 export class FliptClient extends BaseFliptClient {
   private updateInterval?: NodeJS.Timeout;

--- a/flipt-client-js/src/slim/index.ts
+++ b/flipt-client-js/src/slim/index.ts
@@ -1,9 +1,9 @@
 import init, { Engine } from '../wasm/flipt_engine_wasm_js.js';
-import { BaseFliptClient } from '~/core/base';
-import { ClientOptions, ErrorStrategy } from '~/core/types';
+import { BaseFliptClient } from '../core/base';
+import { ClientOptions, ErrorStrategy } from '../core/types';
 
-export * from '~/core/types';
-export * from '~/core/base';
+export * from '../core/types';
+export * from '../core/base';
 
 export interface WasmOptions {
   /**

--- a/flipt-client-js/tsconfig.json
+++ b/flipt-client-js/tsconfig.json
@@ -2,22 +2,30 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "esnext",
-    "lib": ["es2020", "dom"],
+    "lib": [
+      "es2020",
+      "dom"
+    ],
     "declaration": true,
     "declarationDir": "./dist/types",
     "outDir": "./dist",
     "rootDir": "./src",
     "baseUrl": "./src",
-    "paths": {
-      "~/*": ["./*"]
-    },
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "typeRoots": ["./node_modules/@types", "./src/types"]
+    "typeRoots": [
+      "./node_modules/@types",
+      "./src/types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Fixes: #964

Remove path aliases which generate type files with improper imports once built

This now generates relative imports like:

```
import { BaseFliptClient } from '../core/base';
import { ClientOptions } from '../core/types';
export * from '../core/types';
export * from '../core/base';
```