### PR TITLE
chore: try to build smaller libs

### DIFF
--- a/.github/workflows/package-ffi-engine-android.yml
+++ b/.github/workflows/package-ffi-engine-android.yml
@@ -33,7 +33,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        run: rustup update stable && rustup target add ${{ matrix.platform.target }}
+
+        run: |
+          rustup update nightly
+          rustup default nightly
+          rustup target add ${{ matrix.platform.target }}
 
       - uses: actions/cache@v4
         with:
@@ -50,6 +54,8 @@ jobs:
 
       - name: Build
         run: cargo ndk --platform 30 --target ${{ matrix.platform.arch }} build --release
+        env:
+          RUSTFLAGS: "-Zlocation-detail=none -Zfmt-debug=none"
 
       - name: Package
         run: |

--- a/.github/workflows/package-ffi-engine-darwin.yml
+++ b/.github/workflows/package-ffi-engine-darwin.yml
@@ -37,7 +37,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        run: rustup update stable && rustup target add ${{ matrix.platform.target }}
+        run: |
+          rustup update nightly
+          rustup default nightly
+          rustup target add ${{ matrix.platform.target }}
 
       - uses: actions/cache@v4
         with:
@@ -51,6 +54,8 @@ jobs:
 
       - name: Build
         run: cargo build --release --target ${{ matrix.platform.target }} --package flipt-engine-ffi
+        env:
+          RUSTFLAGS: "-Zlocation-detail=none -Zfmt-debug=none"
 
       - name: Strip dylib
         if: contains(matrix.platform.target, 'darwin')

--- a/.github/workflows/package-ffi-engine-linux.yml
+++ b/.github/workflows/package-ffi-engine-linux.yml
@@ -33,7 +33,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        run: rustup update stable
+        run: |
+          rustup update nightly
 
       - name: Install musl-gcc
         run: |

--- a/.github/workflows/package-ffi-engine-windows.yml
+++ b/.github/workflows/package-ffi-engine-windows.yml
@@ -28,7 +28,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        run: rustup update stable && rustup target add ${{ matrix.platform.target }}
+        run: |
+          rustup update nightly
+          rustup default nightly
+          rustup target add ${{ matrix.platform.target }}
 
       - uses: actions/cache@v4
         with:
@@ -42,6 +45,8 @@ jobs:
 
       - name: Build
         run: cargo build --release --target ${{ matrix.platform.target }} --package flipt-engine-ffi
+        env:
+          RUSTFLAGS: "-Zlocation-detail=none -Zfmt-debug=none"
 
       - name: Package
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["./flipt-engine-ffi", "./flipt-engine-wasm", "./flipt-engine-wasm-js"
 [profile.release]
 strip = true
 rpath = true
+codegen-units = 1
 
 [profile.release.package.flipt-engine-wasm]
 opt-level = "s"
@@ -13,4 +14,4 @@ opt-level = "s"
 opt-level = "s"
 
 [profile.release.package.flipt-engine-ffi]
-opt-level = "z"
+opt-level = "s"

--- a/flipt-engine-ffi/build.sh
+++ b/flipt-engine-ffi/build.sh
@@ -12,6 +12,7 @@ fi
 TARGET=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR/.."
+RUST_FLAGS="RUSTFLAGS=-Zlocation-detail=none -Zfmt-debug=none"
 
 case $TARGET in
 "linux-x86_64")
@@ -19,9 +20,11 @@ case $TARGET in
       echo "Error: musl-gcc is not installed. Please install it first."
       exit 1
   fi
+  rustup default nightly
   rustup target add x86_64-unknown-linux-musl
 
-  cargo build -p flipt-engine-ffi --release --target=x86_64-unknown-linux-musl
+  # https://github.com/johnthagen/min-sized-rust
+  $RUST_FLAGS cargo +nightly build -p flipt-engine-ffi --release --target=x86_64-unknown-linux-musl
 
   mkdir -p "/tmp/ffi"
 
@@ -40,10 +43,11 @@ case $TARGET in
       echo "Error: musl-gcc is not installed. Please install it first."
       exit 1
   fi
-
+  rustup default nightly
   rustup target add aarch64-unknown-linux-musl
 
-  cargo build -p flipt-engine-ffi --release --target=aarch64-unknown-linux-musl
+  # https://github.com/johnthagen/min-sized-rust
+  $RUST_FLAGS cargo +nightly build -p flipt-engine-ffi --release --target=aarch64-unknown-linux-musl
 
   mkdir -p "/tmp/ffi"
 

--- a/flipt-engine-ffi/build.sh
+++ b/flipt-engine-ffi/build.sh
@@ -12,7 +12,7 @@ fi
 TARGET=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR/.."
-RUST_FLAGS="RUSTFLAGS=-Zlocation-detail=none -Zfmt-debug=none"
+RUST_FLAGS="-Zlocation-detail=none -Zfmt-debug=none"
 
 case $TARGET in
 "linux-x86_64")
@@ -24,7 +24,7 @@ case $TARGET in
   rustup target add x86_64-unknown-linux-musl
 
   # https://github.com/johnthagen/min-sized-rust
-  $RUST_FLAGS cargo +nightly build -p flipt-engine-ffi --release --target=x86_64-unknown-linux-musl
+  RUSTFLAGS="$RUST_FLAGS" cargo +nightly build -p flipt-engine-ffi --release --target=x86_64-unknown-linux-musl
 
   mkdir -p "/tmp/ffi"
 
@@ -47,7 +47,7 @@ case $TARGET in
   rustup target add aarch64-unknown-linux-musl
 
   # https://github.com/johnthagen/min-sized-rust
-  $RUST_FLAGS cargo +nightly build -p flipt-engine-ffi --release --target=aarch64-unknown-linux-musl
+  RUSTFLAGS="$RUST_FLAGS" cargo +nightly build -p flipt-engine-ffi --release --target=aarch64-unknown-linux-musl
 
   mkdir -p "/tmp/ffi"
 


### PR DESCRIPTION
experiment to build smaller libs for FFI

https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#remove-location-details
https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#remove-fmtdebug

seems to remove about 4-6mb per library which is nice