### PR TITLE
chore: rm android x86_64 support to reduce package size

### DIFF
--- a/package/ffi/sdks/dart.go
+++ b/package/ffi/sdks/dart.go
@@ -22,7 +22,6 @@ func (s *DartSDK) SupportedPlatforms() []platform.Platform {
 		platform.DarwinArm64,
 		platform.WindowsX86_64,
 		platform.AndroidArm64,
-		platform.AndroidX86_64,
 	}
 }
 
@@ -62,7 +61,6 @@ func (s *DartSDK) Build(ctx context.Context, client *dagger.Client, container *d
 	}
 
 	renames := []rename{
-		{old: "android_x86_64", new: "android/src/main/jniLibs/x86_64"},
 		{old: "android_aarch64", new: "android/src/main/jniLibs/arm64-v8a"},
 		{old: "linux_x86_64", new: "native/linux_x86_64"},
 		{old: "linux_aarch64", new: "native/linux_aarch64"},


### PR DESCRIPTION
removing x86_64 android to get the package size down (hopefully) for publishing