### PR TITLE
Use shim for useSyncExternalStore

### DIFF
--- a/flipt-client-react/README.md
+++ b/flipt-client-react/README.md
@@ -12,7 +12,7 @@ npm install @flipt-io/flipt-client-react
 
 ## Prerequisites
 
-- React 18.0 or higher
+- React 16.8.0 or higher
 
 ## Usage
 

--- a/flipt-client-react/package-lock.json
+++ b/flipt-client-react/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@flipt-io/flipt-client-js": "^0.0.6"
+        "@flipt-io/flipt-client-js": "^0.0.6",
+        "use-sync-external-store": "^1.5.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
@@ -20,6 +21,7 @@
         "@testing-library/react": "^16.0.1",
         "@types/jest": "^29.5.13",
         "@types/react": "^18.0.0",
+        "@types/use-sync-external-store": "^1.5.0",
         "@typescript-eslint/eslint-plugin": "^8.11.0",
         "@typescript-eslint/parser": "^8.11.0",
         "eslint": "^9.13.0",
@@ -2020,6 +2022,13 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -6392,8 +6401,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6592,7 +6600,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7409,7 +7416,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8605,6 +8611,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/flipt-client-react/package.json
+++ b/flipt-client-react/package.json
@@ -42,6 +42,7 @@
     "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.5.13",
     "@types/react": "^18.0.0",
+    "@types/use-sync-external-store": "^1.5.0",
     "@typescript-eslint/eslint-plugin": "^8.11.0",
     "@typescript-eslint/parser": "^8.11.0",
     "eslint": "^9.13.0",
@@ -69,6 +70,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@flipt-io/flipt-client-js": "^0.0.6"
+    "@flipt-io/flipt-client-js": "^0.0.6",
+    "use-sync-external-store": "^1.5.0"
   }
 }

--- a/flipt-client-react/package.json
+++ b/flipt-client-react/package.json
@@ -66,8 +66,8 @@
     "typescript": "^5.6.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "dependencies": {
     "@flipt-io/flipt-client-js": "^0.0.6",

--- a/flipt-client-react/src/useFliptClient.ts
+++ b/flipt-client-react/src/useFliptClient.ts
@@ -1,12 +1,12 @@
 import {
   useContext,
-  useSyncExternalStore,
   useCallback,
   createContext,
   useEffect,
   useRef,
   useMemo
 } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import type { FliptClient, ClientOptions } from '@flipt-io/flipt-client-js';
 
 export interface FliptClientHook {


### PR DESCRIPTION
Adding this shim allows the Flipt react SDK to be used in react 17.

Shim package [here](https://www.npmjs.com/package/use-sync-external-store).

It only uses the shim if the hook is not present in the version of react that you're using.