### PR TITLE
Stop fetch before setting snapshot

### DIFF
--- a/flipt-client-go/version.go
+++ b/flipt-client-go/version.go
@@ -1,3 +1,3 @@
 package evaluation
 
-const Version = "0.16.3"
+const Version = "0.17.0"

--- a/flipt-engine-ffi/examples/evaluation.rs
+++ b/flipt-engine-ffi/examples/evaluation.rs
@@ -6,6 +6,7 @@ use fliptengine::{
 };
 use fliptevaluation::EvaluationRequest;
 use std::collections::HashMap;
+use tokio;
 
 fn main() {
     let namespace = "default";
@@ -20,12 +21,12 @@ fn main() {
     let mut context: HashMap<String, String> = HashMap::new();
     context.insert("fizz".into(), "buzz".into());
 
-    std::thread::sleep(std::time::Duration::from_millis(5000));
-    let variant = engine.variant(&EvaluationRequest {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let variant = rt.block_on(engine.variant_async(&EvaluationRequest {
         flag_key: "flag1".into(),
         entity_id: "entity".into(),
         context: context.clone(),
-    });
+    }));
 
     println!("variant key {:?}", variant.unwrap().variant_key);
 }

--- a/flipt-engine-wasm/src/lib.rs
+++ b/flipt-engine-wasm/src/lib.rs
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn initialize_engine(
             match std::str::from_utf8(std::slice::from_raw_parts(namespace_ptr, namespace_len)) {
                 Ok(s) => s,
                 Err(e) => {
-                    eprintln!("Invalid UTF-8 in namespace: {}", e);
+                    eprintln!("Invalid UTF-8 in namespace: {e}");
                     return std::ptr::null_mut();
                 }
             };
@@ -166,7 +166,7 @@ pub unsafe extern "C" fn initialize_engine(
             match std::str::from_utf8(std::slice::from_raw_parts(payload_ptr, payload_len)) {
                 Ok(s) => s,
                 Err(e) => {
-                    eprintln!("Invalid UTF-8 in payload: {}", e);
+                    eprintln!("Invalid UTF-8 in payload: {e}");
                     return std::ptr::null_mut();
                 }
             };
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn initialize_engine(
         match Engine::new(namespace, payload) {
             Ok(engine) => Box::into_raw(Box::new(engine)) as *mut c_void,
             Err(e) => {
-                eprintln!("Error initializing engine: {}", e);
+                eprintln!("Error initializing engine: {e}");
                 std::ptr::null_mut()
             }
         }


### PR DESCRIPTION
Try to fix the deadlocks occurring when setting the snapshot with the http fetcher still running in the bg.

ie: https://github.com/flipt-io/flipt-client-sdks/actions/runs/15420100528/job/43392615414?pr=1050

The idea is now the fetcher will be stopped/interrupted before setting the snapshot and restarted after.

We could optionally expose start/stop to the callers too, but id prefer not to if its not necessary