### PR TITLE
feat: add snapshot support to swift sdk; refactor a bit

### DIFF
--- a/.github/workflows/package-ffi-engine-darwin.yml
+++ b/.github/workflows/package-ffi-engine-darwin.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
-            const tag = context.ref.replace('refs/tags/', '');
+            const release_tag = context.ref.replace('refs/tags/', '');
 
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
@@ -111,8 +111,8 @@ jobs:
               workflow_id: 'package-ffi-engine-ios.yml',
               ref: 'main',
               inputs: {
-                tag: tag
+                release_tag: release_tag
               }
             });
 
-            console.log(`Successfully triggered iOS packaging workflow for tag: ${tag}`);
+            console.log(`Successfully triggered iOS packaging workflow for release tag: ${release_tag}`);

--- a/.github/workflows/package-ffi-engine-ios.yml
+++ b/.github/workflows/package-ffi-engine-ios.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       release_tag:
         description: 'Release tag to upload XCFramework to (e.g. flipt-engine-ffi-v0.9.0)'
-        required: false
+        required: true
         type: string
 
 permissions:

--- a/.github/workflows/package-ffi-engine-ios.yml
+++ b/.github/workflows/package-ffi-engine-ios.yml
@@ -2,8 +2,10 @@ name: Package FFI Engine (iOS)
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        required: true
+      release_tag:
+        description: 'Release tag to upload XCFramework to (e.g. flipt-engine-ffi-v0.9.0)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -27,7 +29,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const tag = '${{ inputs.tag }}';
+            const tag = '${{ inputs.release_tag }}';
             const { data: release } = await github.rest.repos.getReleaseByTag({
               owner,
               repo,
@@ -133,7 +135,7 @@ jobs:
 
       - name: Upload Release Assets (Tag)
         uses: softprops/action-gh-release@v2.2.1
-        if: startsWith(inputs.tag, 'flipt-engine-ffi-v')
+        if: startsWith(inputs.release_tag, 'flipt-engine-ffi-v')
         with:
-          tag_name: ${{ inputs.tag }}
+          tag_name: ${{ inputs.release_tag }}
           files: /tmp/Sources/FliptEngineFFI.xcframework.tar.gz

--- a/.github/workflows/test-swift-sdk.yml
+++ b/.github/workflows/test-swift-sdk.yml
@@ -3,6 +3,12 @@ on:
   workflow_run:
     workflows: ["Package FFI Engine (Darwin)"]
     types: [requested, completed]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to download prebuilt xcframework (e.g. flipt-engine-ffi-v0.9.0)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -30,10 +36,54 @@ jobs:
               target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             });
 
-  test:
-    name: Integration Tests
+  test-prebuilt:
+    name: Integration Tests (Prebuilt XCFramework)
     runs-on: macos-14
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' }}
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Install Flipt
+        uses: flipt-io/setup-action@v0.3.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Prebuilt XCFramework
+        run: |
+          curl -L -o FliptEngineFFI.xcframework.tar.gz \
+            https://github.com/flipt-io/flipt-client-sdks/releases/download/${{ github.event.inputs.release_tag }}/FliptEngineFFI.xcframework.tar.gz
+          mkdir -p flipt-client-swift/Sources/
+          tar -xzvf FliptEngineFFI.xcframework.tar.gz -C flipt-client-swift/Sources/
+
+      - name: Run Flipt
+        env:
+          FLIPT_STORAGE_TYPE: "local"
+          FLIPT_STORAGE_LOCAL_PATH: "./test/fixtures/testdata"
+          FLIPT_AUTHENTICATION_REQUIRED: true
+          FLIPT_AUTHENTICATION_METHODS_TOKEN_ENABLED: true
+          FLIPT_AUTHENTICATION_METHODS_TOKEN_BOOTSTRAP_TOKEN: "secret"
+        run: flipt&
+
+      - name: Wait for Flipt to be ready
+        run: |
+          while ! curl -s http://0.0.0.0:8080/health | grep -q "SERVING"; do
+            echo "Waiting for Flipt to be ready..."
+            sleep 1
+          done
+
+      - name: Run Integration Tests
+        env:
+          FLIPT_URL: "http://0.0.0.0:8080"
+          FLIPT_AUTH_TOKEN: "secret"
+        run: |
+          cd ./flipt-client-swift
+          swift test
+
+  test-package:
+    name: Integration Tests (Package FFI Engine)
+    runs-on: macos-14
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 20
     steps:
       - name: Checkout Sources
@@ -150,19 +200,24 @@ jobs:
           cd ./flipt-client-swift
           swift test
 
+  update-status-check:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [test-prebuilt, test-package]
+    steps:
       - name: Update Status Check
-        if: always()
         uses: actions/github-script@v7
         with:
           script: |
-            const sha = context.payload.workflow_run.head_sha;
+            const sha = context.payload.workflow_run ? context.payload.workflow_run.head_sha : context.sha;
             const { owner, repo } = context.repo;
+            const jobStatus = process.env.JOB_STATUS || (process.env.GITHUB_JOB == 'test-prebuilt' ? 'success' : 'failure');
             await github.rest.repos.createCommitStatus({
               owner,
               repo,
               sha: sha,
-              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
+              state: jobStatus === 'success' ? 'success' : 'failure',
               context: 'Swift SDK Tests',
-              description: '${{ job.status }}' === 'success' ? 'Tests passed' : 'Tests failed',
-              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+              description: jobStatus === 'success' ? 'Tests passed' : 'Tests failed',
+              target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
             });

--- a/flipt-client-swift/Sources/FliptClient/FliptClient.swift
+++ b/flipt-client-swift/Sources/FliptClient/FliptClient.swift
@@ -4,54 +4,61 @@ import Foundation
 public class FliptClient {
     private var engine: UnsafeMutableRawPointer?
     private var namespace: String = "default"
-    private var url: String = ""
+    private var url: String = "http://localhost:8080"
     private var authentication: Authentication?
-    private var ref: String = ""
+    private var reference: String?
     private var requestTimeout: Int = 0
-    private var updateInterval: Int = 0
+    private var updateInterval: Int = 120
     private var fetchMode: FetchMode = .polling
     private var errorStrategy: ErrorStrategy = .fail
+    private var snapshot: String?
 
     public init(
-        namespace: String = "default",
-        url: String = "",
+        namespace: String? = nil,
+        url: String? = nil,
         authentication: Authentication? = nil,
-        ref: String = "",
-        requestTimeout: Int = 0,
-        updateInterval: Int = 120,
+        reference: String? = nil,
+        requestTimeout: Duration? = nil,
+        updateInterval: Duration? = nil,
         fetchMode: FetchMode = .polling,
-        errorStrategy: ErrorStrategy = .fail) throws
+        errorStrategy: ErrorStrategy = .fail,
+        snapshot: String? = nil) throws
     {
-        self.namespace = namespace
-        self.url = url
+        self.namespace = namespace ?? "default"
+        self.url = url ?? "http://localhost:8080"
         self.authentication = authentication
-        self.ref = ref
-        self.requestTimeout = requestTimeout
-        self.updateInterval = updateInterval
+        self.requestTimeout = requestTimeout?.components.seconds ?? 0
+        self.updateInterval = updateInterval?.components.seconds ?? 120
+        self.reference = reference
         self.fetchMode = fetchMode
         self.errorStrategy = errorStrategy
+        self.snapshot = snapshot
 
         let clientOptions = ClientOptions(
-            url: url,
+            url: self.url,
             authentication: authentication,
-            requestTimeout: requestTimeout,
-            updateInterval: updateInterval,
-            reference: ref,
+            requestTimeout: self.requestTimeout,
+            updateInterval: self.updateInterval,
+            reference: self.reference,
             fetchMode: fetchMode,
-            errorStrategy: errorStrategy)
+            errorStrategy: errorStrategy,
+            snapshot: self.snapshot)
 
-        guard let jsonData = try? JSONEncoder().encode(clientOptions) else {
+        guard let jsonData = try? JSONEncoder().encode(clientOptions),
+              let jsonStr = String(data: jsonData, encoding: .utf8)
+        else {
             throw ClientError.invalidOptions
         }
 
-        let jsonStr = String(data: jsonData, encoding: .utf8)
-        let namespaceCString = strdup(namespace)
+        let namespaceCString = strdup(self.namespace)
         let clientOptionsCString = strdup(jsonStr)
 
-        engine = initialize_engine(namespaceCString, clientOptionsCString)
+        defer {
+            free(namespaceCString)
+            free(clientOptionsCString)
+        }
 
-        free(namespaceCString)
-        free(clientOptionsCString)
+        engine = initialize_engine(namespaceCString, clientOptionsCString)
     }
 
     deinit {
@@ -213,6 +220,15 @@ public class FliptClient {
         }
 
         return result
+    }
+
+    public func getSnapshot() throws -> String {
+        guard let snapshotCString = get_snapshot(engine) else {
+            throw ClientError.evaluationFailed(message: "No response from engine")
+        }
+        let snapshot = String(cString: snapshotCString)
+        destroy_string(UnsafeMutablePointer(mutating: snapshotCString))
+        return snapshot
     }
 
     public enum ClientError: Error {

--- a/flipt-client-swift/Tests/FliptClientTests/Resources/empty_snapshot.json
+++ b/flipt-client-swift/Tests/FliptClientTests/Resources/empty_snapshot.json
@@ -1,0 +1,10 @@
+{
+    "version": 1,
+    "namespace": {
+        "key": "default",
+        "flags": {},
+        "eval_rules": {},
+        "eval_rollouts": {},
+        "eval_distributions": {}
+    }
+}

--- a/flipt-client-swift/Tests/FliptClientTests/Resources/snapshot.json
+++ b/flipt-client-swift/Tests/FliptClientTests/Resources/snapshot.json
@@ -1,0 +1,89 @@
+{
+    "version": 1,
+    "namespace": {
+        "key": "default",
+        "flags": {
+            "flag1": {
+                "key": "flag1",
+                "enabled": true,
+                "type": "VARIANT_FLAG_TYPE",
+                "description": "flag description"
+            },
+            "flag_boolean": {
+                "key": "flag_boolean",
+                "enabled": true,
+                "type": "BOOLEAN_FLAG_TYPE",
+                "description": "flag description"
+            }
+        },
+        "eval_rules": {
+            "flag1": [
+                {
+                    "id": "flag1-1",
+                    "flag_key": "flag1",
+                    "segments": {
+                        "segment1": {
+                            "segment_key": "segment1",
+                            "match_type": "ANY_SEGMENT_MATCH_TYPE",
+                            "constraints": [
+                                {
+                                    "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                                    "property": "fizz",
+                                    "operator": "eq",
+                                    "value": "buzz"
+                                }
+                            ]
+                        }
+                    },
+                    "rank": 1,
+                    "segment_operator": "OR_SEGMENT_OPERATOR"
+                }
+            ],
+            "flag_boolean": []
+        },
+        "eval_rollouts": {
+            "flag1": [],
+            "flag_boolean": [
+                {
+                    "rollout_type": "SEGMENT_ROLLOUT_TYPE",
+                    "rank": 1,
+                    "segment": {
+                        "value": true,
+                        "segment_operator": "OR_SEGMENT_OPERATOR",
+                        "segments": {
+                            "segment1": {
+                                "segment_key": "segment1",
+                                "match_type": "ANY_SEGMENT_MATCH_TYPE",
+                                "constraints": [
+                                    {
+                                        "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+                                        "property": "fizz",
+                                        "operator": "eq",
+                                        "value": "buzz"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "rollout_type": "THRESHOLD_ROLLOUT_TYPE",
+                    "rank": 2,
+                    "threshold": {
+                        "percentage": 50.0,
+                        "value": true
+                    }
+                }
+            ]
+        },
+        "eval_distributions": {
+            "flag1-1": [
+                {
+                    "rule_id": "flag1-1",
+                    "rollout": 100.0,
+                    "variant_key": "variant1"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
this should add snapshot support for our Swift SDK

it also:

- makes the client a bit more idiomatic swift (breaking change)
- adds ability to run ios swift tests using the prebuild xcframework from a release (useful if just testing swift code changes)