### PR TITLE
chore!(dart): rm macos x86 support to decrease file size

### DIFF
--- a/flipt-client-dart/README.md
+++ b/flipt-client-dart/README.md
@@ -57,7 +57,6 @@ This SDK currently supports the following OSes/architectures:
 
 - Linux x86_64
 - Linux arm64
-- MacOS x86_64
 - MacOS arm64
 - Windows x86_64
 - Android arm64
@@ -73,6 +72,7 @@ This section is for users who are migrating from a previous (pre-1.0.0) version 
 - `FliptEvaluationClient` has been renamed to `FliptClient`.
 - `Options` now accept `namespace` and `environment` as optional parameters.
 - `requestTimeout` and `updateInterval` in `Options` are now `Duration` types instead of `int` (seconds). Update your code to use `Duration(seconds: ...)`.
+- MacOS x86_64 is no longer supported as pub.dev enforces a file size limit of published packages so we cannot include every architecture in the SDK.
 
 ## Usage
 

--- a/flipt-client-dart/lib/src/ffi/loader.dart
+++ b/flipt-client-dart/lib/src/ffi/loader.dart
@@ -35,8 +35,11 @@ LibraryConfig getPlatformConfig(Architecture arch) {
   // We only need platform configs for desktop platforms
   // Android and iOS are handled directly in their respective loaders
   if (Platform.isMacOS) {
-    final dir = arch == Architecture.arm64 ? 'darwin_aarch64' : 'darwin_x86_64';
-    return LibraryConfig(dir, 'libfliptengine.dylib');
+    if (arch == Architecture.x86_64) {
+      throw UnsupportedError('x86_64 is no longer supported on macOS');
+    }
+
+    return LibraryConfig('darwin_aarch64', 'libfliptengine.dylib');
   }
 
   if (Platform.isLinux) {

--- a/flipt-client-dart/pubspec.yaml
+++ b/flipt-client-dart/pubspec.yaml
@@ -21,7 +21,6 @@ environment:
   sdk: '>=2.17.0 <4.0.0'
 files:
 - native/darwin_aarch64/libfliptengine.dylib
-- native/darwin_x86_64/libfliptengine.dylib
 - native/linux_aarch64/libfliptengine.so
 - native/linux_x86_64/libfliptengine.so
 - native/windows_x86_64/fliptengine.dll
@@ -29,7 +28,6 @@ files:
 flutter:
   assets:
   - native/darwin_aarch64/libfliptengine.dylib
-  - native/darwin_x86_64/libfliptengine.dylib
   - native/linux_aarch64/libfliptengine.so
   - native/linux_x86_64/libfliptengine.so
   - native/windows_x86_64/fliptengine.dll

--- a/package/ffi/sdks/dart.go
+++ b/package/ffi/sdks/dart.go
@@ -18,7 +18,6 @@ func (s *DartSDK) SupportedPlatforms() []platform.Platform {
 	return []platform.Platform{
 		platform.LinuxX86_64,
 		platform.LinuxArm64,
-		platform.DarwinX86_64,
 		platform.DarwinArm64,
 		platform.WindowsX86_64,
 		platform.AndroidArm64,


### PR DESCRIPTION
remove support for mac0S x86 for Dart as we keep running into package size issues on publish:

https://github.com/flipt-io/flipt-client-sdks/actions/runs/15537275378/job/43739269588#step:7:3075

ie: `Message from server: Uncompressed package archive is too large (size > 104857600).`