### PR TITLE
feat: more debug logging for http failures

### DIFF
--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["rlib", "dylib", "staticlib"]
 libc = { version = "0.2.150", features = ["std"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }
-reqwest = { version = "0.12.9", features = ["json", "stream", "rustls-tls", "http2"], default-features = false }
+reqwest = { version = "0.12.9", features = ["json", "stream", "rustls-tls-native-roots", "http2"], default-features = false }
 http = "1.0"
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros", "io-util", "net", "time"], default-features = false }
 tokio-util = { version = "0.7", features = ["io"], default-features = false }

--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["rlib", "dylib", "staticlib"]
 libc = { version = "0.2.150", features = ["std"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }
-reqwest = { version = "0.12.9", features = ["json", "stream", "rustls-tls-native-roots", "http2"], default-features = false }
+reqwest = { version = "0.12.9", features = ["json", "stream", "rustls-tls", "http2"], default-features = false }
 http = "1.0"
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros", "io-util", "net", "time"], default-features = false }
 tokio-util = { version = "0.7", features = ["io"], default-features = false }

--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -17,6 +17,7 @@ libc = { version = "0.2.150", features = ["std"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }
 reqwest = { version = "0.12.9", features = ["json", "stream", "rustls-tls", "http2"], default-features = false }
+http = "1.0"
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros", "io-util", "net", "time"], default-features = false }
 tokio-util = { version = "0.7", features = ["io"], default-features = false }
 futures-util = { version = "0.3.30", default-features = false }
@@ -24,6 +25,7 @@ futures = { version = "0.3", default-features = false }
 thiserror = "2.0.3"
 reqwest-retry = "0.7.0"
 reqwest-middleware = "0.4.0"
+async-trait = "0.1"
 base64 = "0.22"
 log = "0.4"
 env_logger = "0.11"

--- a/flipt-engine-ffi/src/http.rs
+++ b/flipt-engine-ffi/src/http.rs
@@ -559,6 +559,8 @@ fn configure_tls(
     mut builder: reqwest::ClientBuilder,
     tls_config: &TlsConfig,
 ) -> Result<reqwest::ClientBuilder, Error> {
+    builder = builder.use_rustls_tls();
+
     // Handle insecure mode
     if tls_config.insecure_skip_verify.unwrap_or(false) {
         builder = builder.danger_accept_invalid_certs(true);


### PR DESCRIPTION
adds a bit more logging for each request, not just after all retries are exhausted

**Update**: This also 'forces' rustls usage by reqwest which i didnt realize wasnt guaranteed : https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.use_rustls_tls

Perhaps this will fix the underlying TLS issues we are seeing in https://github.com/orgs/flipt-io/discussions/4366

Theres quite a bit of traction to use rustls by default in reqwest fwiw: https://github.com/seanmonstar/reqwest/issues/2025

```
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG fliptengine::http] request GET http://invalid.flipt.com/internal/v1/evaluation/snapshot/namespace/default
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG reqwest::connect] starting new connection:
70  : [46.9s] | [2025-07-02T20:45:28Z WARN  fliptengine::http] error GET http://invalid.flipt.com/internal/v1/evaluation/snapshot/namespace/default -> error sending request for url (http://invalid.flipt.com/internal/v1/evaluation/snapshot/namespace/default) (source: client error ()) in
70  : [46.9s] | [2025-07-02T20:45:28Z WARN  fliptengine] fetch failed:
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG fliptengine::http] loading CA certificate from file: /src/test/fixtures/tls/ca.crt
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG fliptengine::http] successfully added CA certificate from file: /src/test/fixtures/tls/ca.crt
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG fliptengine::http] request GET https://flipt:8443/internal/v1/evaluation/snapshot/namespace/default
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG reqwest::connect] starting new connection:
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG fliptengine::http] response GET https://flipt:8443/internal/v1/evaluation/snapshot/namespace/default -> 200 OK OK in
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG fliptengine] initial fetch succeeded
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG fliptengine::http] request GET https://flipt:8443/internal/v1/evaluation/snapshot/namespace/default
70  : [46.9s] | [2025-07-02T20:45:28Z DEBUG fliptengine::http] response GET https://flipt:8443/internal/v1/evaluation/snapshot/namespace/default -> 304 Not Modified Not Modified
```