### PR TITLE
chore: update kotlin android sdk to use new sonatype portal

### DIFF
--- a/flipt-client-kotlin-android/build.gradle
+++ b/flipt-client-kotlin-android/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "org.jlleitschuh.gradle.ktlint" version "12.3.0"
-    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 group = 'io.flipt'
@@ -106,17 +106,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username "$System.env.MAVEN_USERNAME"
-                password "$System.env.MAVEN_PASSWORD"
-            }
-        }
-    }
 }
 
 signing {
@@ -129,10 +118,10 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-            username = System.getenv("MAVEN_USERNAME")
-            password = System.getenv("MAVEN_PASSWORD")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username = System.getenv("SONATYPE_PORTAL_USERNAME")
+            password = System.getenv("SONATYPE_PORTAL_PASSWORD")
             packageGroup = "io.flipt"
         }
     }

--- a/package/ffi/sdks/android.go
+++ b/package/ffi/sdks/android.go
@@ -116,14 +116,11 @@ func (s *AndroidSDK) Build(ctx context.Context, client *dagger.Client, container
 		return nil
 	}
 
-	if os.Getenv("MAVEN_USERNAME") == "" {
-		return fmt.Errorf("MAVEN_USERNAME is not set")
+	if os.Getenv("SONATYPE_PORTAL_USERNAME") == "" {
+		return fmt.Errorf("SONATYPE_PORTAL_USERNAME is not set")
 	}
-	if os.Getenv("MAVEN_PASSWORD") == "" {
-		return fmt.Errorf("MAVEN_PASSWORD is not set")
-	}
-	if os.Getenv("MAVEN_PUBLISH_REGISTRY_URL") == "" {
-		return fmt.Errorf("MAVEN_PUBLISH_REGISTRY_URL is not set")
+	if os.Getenv("SONATYPE_PORTAL_PASSWORD") == "" {
+		return fmt.Errorf("SONATYPE_PORTAL_PASSWORD is not set")
 	}
 	if os.Getenv("PGP_PRIVATE_KEY") == "" {
 		return fmt.Errorf("PGP_PRIVATE_KEY is not set")
@@ -133,16 +130,14 @@ func (s *AndroidSDK) Build(ctx context.Context, client *dagger.Client, container
 	}
 
 	var (
-		mavenUsername    = client.SetSecret("maven-username", os.Getenv("MAVEN_USERNAME"))
-		mavenPassword    = client.SetSecret("maven-password", os.Getenv("MAVEN_PASSWORD"))
-		mavenRegistryUrl = client.SetSecret("maven-registry-url", os.Getenv("MAVEN_PUBLISH_REGISTRY_URL"))
-		pgpPrivateKey    = client.SetSecret("pgp-private-key", os.Getenv("PGP_PRIVATE_KEY"))
-		pgpPassphrase    = client.SetSecret("pgp-passphrase", os.Getenv("PGP_PASSPHRASE"))
+		sonatypePortalUsername = client.SetSecret("sonatype-portal-username", os.Getenv("SONATYPE_PORTAL_USERNAME"))
+		sonatypePortalPassword = client.SetSecret("sonatype-portal-password", os.Getenv("SONATYPE_PORTAL_PASSWORD"))
+		pgpPrivateKey          = client.SetSecret("pgp-private-key", os.Getenv("PGP_PRIVATE_KEY"))
+		pgpPassphrase          = client.SetSecret("pgp-passphrase", os.Getenv("PGP_PASSPHRASE"))
 	)
 
-	_, err = container.WithSecretVariable("MAVEN_USERNAME", mavenUsername).
-		WithSecretVariable("MAVEN_PASSWORD", mavenPassword).
-		WithSecretVariable("MAVEN_PUBLISH_REGISTRY_URL", mavenRegistryUrl).
+	_, err = container.WithSecretVariable("SONATYPE_PORTAL_USERNAME", sonatypePortalUsername).
+		WithSecretVariable("SONATYPE_PORTAL_PASSWORD", sonatypePortalPassword).
 		WithSecretVariable("PGP_PRIVATE_KEY", pgpPrivateKey).
 		WithSecretVariable("PGP_PASSPHRASE", pgpPassphrase).
 		WithExec(args("gradle publishToSonatype closeAndReleaseSonatypeStagingRepository")).


### PR DESCRIPTION
## Summary

Updates the Kotlin Android SDK to use the new Sonatype Central Portal configuration, bringing it in line with the Java SDK changes from commits c8fe178 and 83a3504.

## Changes Made

### Build Configuration (`flipt-client-kotlin-android/build.gradle`)
- ✅ Upgraded nexus plugin from version 1.3.0 to 2.0.0
- ✅ Updated Sonatype URLs:
  - From: `https://s01.oss.sonatype.org/service/local/`
  - To: `https://ossrh-staging-api.central.sonatype.com/service/local/`
- ✅ Updated snapshot repository URL:
  - From: `https://s01.oss.sonatype.org/content/repositories/snapshots/`
  - To: `https://central.sonatype.com/repository/maven-snapshots/`
- ✅ Updated environment variables:
  - From: `MAVEN_USERNAME` / `MAVEN_PASSWORD`
  - To: `SONATYPE_PORTAL_USERNAME` / `SONATYPE_PORTAL_PASSWORD`
- ✅ Removed old maven repository configuration (now handled by nexus plugin)

### Packaging Script (`package/ffi/sdks/android.go`)
- ✅ Updated environment variable validation to use new portal credentials
- ✅ Updated secret variable creation to use new credential names
- ✅ Removed dependency on `MAVEN_PUBLISH_REGISTRY_URL` (no longer needed)
- ✅ Maintained `gradle publishToSonatype closeAndReleaseSonatypeStagingRepository` command

## Related

- Follows the same pattern as Java SDK updates in commits:
  - c8fe178 (nexus plugin and build.gradle changes)
  - 83a3504 (workflow and packaging script changes)