### PR TITLE
feat(python): add insecure_skip_hostname_verify support to TlsConfig

### DIFF
--- a/flipt-client-python/README.md
+++ b/flipt-client-python/README.md
@@ -125,6 +125,7 @@ The `tls_config` option accepts a `TlsConfig` object with the following options:
 - `ca_cert_file`: Path to custom CA certificate file (PEM format). Use this to trust self-signed certificates or custom certificate authorities.
 - `ca_cert_data`: Raw CA certificate content (PEM format). Alternative to `ca_cert_file` for providing certificate data directly.
 - `insecure_skip_verify`: Skip certificate verification (development only). Set to `True` to disable TLS certificate and hostname verification. **Warning: Only use this for development/testing.**
+- `insecure_skip_hostname_verify`: Skip hostname verification while maintaining certificate validation (development only). Set to `True` to disable hostname verification but still validate the certificate chain. **Warning: Only use this for development/testing.**
 - `client_cert_file`: Client certificate file for mutual TLS (PEM format). Required for mTLS authentication.
 - `client_key_file`: Client key file for mutual TLS (PEM format). Required for mTLS authentication.
 - `client_cert_data`: Raw client certificate content (PEM format). Alternative to `client_cert_file`.
@@ -158,6 +159,23 @@ client = FliptClient(
 ```python
 tls_config = TlsConfig(
     insecure_skip_verify=True
+)
+
+client = FliptClient(
+    opts=ClientOptions(
+        url="https://localhost:8443",
+        tls_config=tls_config
+    )
+)
+```
+
+**Self-signed certificate with hostname mismatch:**
+
+```python
+# For self-signed certificates with hostname mismatch
+tls_config = TlsConfig(
+    ca_cert_file="/path/to/ca.crt",
+    insecure_skip_hostname_verify=True
 )
 
 client = FliptClient(

--- a/flipt-client-python/flipt_client/models.py
+++ b/flipt-client-python/flipt_client/models.py
@@ -58,22 +58,25 @@ class ErrorStrategy(Enum):
 class TlsConfig(BaseModel):
     """TLS configuration for connecting to Flipt servers with custom certificates."""
 
-    ca_cert_file: Optional[str] = (
-        None  #: Path to custom CA certificate file (PEM format).
-    )
+    ca_cert_file: Optional[
+        str
+    ] = None  #: Path to custom CA certificate file (PEM format).
     ca_cert_data: Optional[str] = None  #: Raw CA certificate content (PEM format).
-    insecure_skip_verify: Optional[bool] = (
-        None  #: Skip certificate verification (development only).
-    )
-    client_cert_file: Optional[str] = (
-        None  #: Client certificate file for mutual TLS (PEM format).
-    )
-    client_key_file: Optional[str] = (
-        None  #: Client key file for mutual TLS (PEM format).
-    )
-    client_cert_data: Optional[str] = (
-        None  #: Raw client certificate content (PEM format).
-    )
+    insecure_skip_verify: Optional[
+        bool
+    ] = None  #: Skip certificate verification (development only).
+    insecure_skip_hostname_verify: Optional[
+        bool
+    ] = None  #: Skip hostname verification while maintaining certificate validation (development only).
+    client_cert_file: Optional[
+        str
+    ] = None  #: Client certificate file for mutual TLS (PEM format).
+    client_key_file: Optional[
+        str
+    ] = None  #: Client key file for mutual TLS (PEM format).
+    client_cert_data: Optional[
+        str
+    ] = None  #: Raw client certificate content (PEM format).
     client_key_data: Optional[str] = None  #: Raw client key content (PEM format).
 
     if PYDANTIC_V2:
@@ -128,9 +131,9 @@ class ClientOptions(BaseModel):
     fetch_mode: Optional[FetchMode] = None  #: Fetch mode.
     error_strategy: Optional[ErrorStrategy] = None  #: Error handling strategy.
     snapshot: Optional[str] = None  #: Snapshot to use to initialize the client.
-    tls_config: Optional[TlsConfig] = (
-        None  #: TLS configuration for connecting to servers with custom certificates.
-    )
+    tls_config: Optional[
+        TlsConfig
+    ] = None  #: TLS configuration for connecting to servers with custom certificates.
 
     if PYDANTIC_V2:
         from pydantic import field_serializer, field_validator
@@ -229,9 +232,9 @@ class VariantResult(BaseModel):
     """Result wrapper for variant evaluation."""
 
     status: str  #: Status of the evaluation (e.g., 'success', 'error').
-    result: Optional[VariantEvaluationResponse] = (
-        None  #: The evaluation response if successful.
-    )
+    result: Optional[
+        VariantEvaluationResponse
+    ] = None  #: The evaluation response if successful.
     error_message: Optional[str] = None  #: Error message if failed.
 
 
@@ -239,9 +242,9 @@ class BooleanResult(BaseModel):
     """Result wrapper for boolean evaluation."""
 
     status: str  #: Status of the evaluation (e.g., 'success', 'error').
-    result: Optional[BooleanEvaluationResponse] = (
-        None  #: The evaluation response if successful.
-    )
+    result: Optional[
+        BooleanEvaluationResponse
+    ] = None  #: The evaluation response if successful.
     error_message: Optional[str] = None  #: Error message if failed.
 
 
@@ -249,9 +252,9 @@ class BatchResult(BaseModel):
     """Result wrapper for batch evaluation."""
 
     status: str  #: Status of the evaluation (e.g., 'success', 'error').
-    result: Optional[BatchEvaluationResponse] = (
-        None  #: The batch evaluation response if successful.
-    )
+    result: Optional[
+        BatchEvaluationResponse
+    ] = None  #: The batch evaluation response if successful.
     error_message: Optional[str] = None  #: Error message if failed.
 
 

--- a/flipt-client-python/tests/test_flipt_client.py
+++ b/flipt-client-python/tests/test_flipt_client.py
@@ -286,3 +286,33 @@ class TestFliptClient(unittest.TestCase):
 
         # update_interval should not be present in the JSON
         self.assertNotIn("update_interval", json_obj)
+
+    def test_tls_config_serialization_insecure_skip_hostname_verify(self):
+        """Test that TlsConfig serializes insecure_skip_hostname_verify correctly"""
+        tls_config = TlsConfig(
+            ca_cert_file="/path/to/ca.crt",
+            insecure_skip_hostname_verify=True,
+        )
+
+        # Serialize to JSON
+        json_str = model_to_json(tls_config, exclude_none=True)
+        json_obj = json.loads(json_str)
+
+        # Should include the field
+        self.assertEqual(json_obj["ca_cert_file"], "/path/to/ca.crt")
+        self.assertEqual(json_obj["insecure_skip_hostname_verify"], True)
+
+    def test_tls_config_serialization_exclude_none_hostname_verify(self):
+        """Test that TlsConfig excludes None insecure_skip_hostname_verify"""
+        tls_config = TlsConfig(
+            ca_cert_file="/path/to/ca.crt",
+            insecure_skip_hostname_verify=None,
+        )
+
+        # Serialize to JSON excluding None values
+        json_str = model_to_json(tls_config, exclude_none=True)
+        json_obj = json.loads(json_str)
+
+        # Should include ca_cert_file but not insecure_skip_hostname_verify
+        self.assertEqual(json_obj["ca_cert_file"], "/path/to/ca.crt")
+        self.assertNotIn("insecure_skip_hostname_verify", json_obj)


### PR DESCRIPTION
## Summary

Adds `insecure_skip_hostname_verify` support to the Python SDK `TlsConfig` class for handling self-signed certificates with hostname mismatches.

- Add `insecure_skip_hostname_verify` field to `TlsConfig` model
- Update README documentation with usage examples
- Add unit tests for JSON serialization behavior
- Follow Python naming conventions (snake_case)

## Changes

- **Model Update**: Added `insecure_skip_hostname_verify: Optional[bool]` field to `TlsConfig` class in `models.py`
- **Documentation**: Updated README with field description and usage example for self-signed certificates with hostname mismatches
- **Tests**: Added two unit tests to verify JSON serialization works correctly (includes field when `True`, excludes when `None`)

## Usage Example

```python
# For self-signed certificates with hostname mismatch
tls_config = TlsConfig(
    ca_cert_file="/path/to/ca.crt",
    insecure_skip_hostname_verify=True  # Skip hostname verification only
)

client = FliptClient(
    opts=ClientOptions(
        url="https://localhost:8443",
        tls_config=tls_config
    )
)
```

## Testing

- JSON serialization tests pass
- Code formatted with Black
- Follows existing TLS configuration patterns

## References

- Fixes #1170
- Matches Java SDK implementation pattern
- FFI engine already supports this field (`flipt-engine-ffi/src/tls.rs:13`)

This is part 1 of 6 for adding `insecure_skip_hostname_verify` support to all FFI-based SDKs.