### PR TITLE
feat(ruby): add insecure_skip_hostname_verify support to TlsConfig

### DIFF
--- a/flipt-client-ruby/Gemfile.lock
+++ b/flipt-client-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flipt_client (1.0.0)
+    flipt_client (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/flipt-client-ruby/README.md
+++ b/flipt-client-ruby/README.md
@@ -212,6 +212,23 @@ client = Flipt::Client.new(
 )
 ```
 
+#### Self-Signed Certificates
+
+For self-signed certificates where you need to skip hostname verification while still validating the certificate chain:
+
+```ruby
+# Skip hostname verification for self-signed certificates
+tls_config = Flipt::TlsConfig.new(
+  ca_cert_file: '/path/to/ca.pem',
+  insecure_skip_hostname_verify: true
+)
+
+client = Flipt::Client.new(
+  url: 'https://flipt.example.com',
+  tls_config: tls_config
+)
+```
+
 #### TLS Configuration Options
 
 The `TlsConfig` class supports the following options:
@@ -219,6 +236,7 @@ The `TlsConfig` class supports the following options:
 - `ca_cert_file`: Path to custom CA certificate file (PEM format)
 - `ca_cert_data`: Raw CA certificate content (PEM format) - takes precedence over `ca_cert_file`
 - `insecure_skip_verify`: Skip certificate verification (development only)
+- `insecure_skip_hostname_verify`: Skip hostname verification while maintaining certificate validation (development only)
 - `client_cert_file`: Client certificate file for mutual TLS (PEM format)
 - `client_key_file`: Client private key file for mutual TLS (PEM format)
 - `client_cert_data`: Raw client certificate content (PEM format) - takes precedence over `client_cert_file`

--- a/flipt-client-ruby/lib/flipt_client/models.rb
+++ b/flipt-client-ruby/lib/flipt_client/models.rb
@@ -43,7 +43,7 @@ module Flipt
 
   # TlsConfig provides configuration for TLS connections to Flipt servers
   class TlsConfig
-    attr_reader :ca_cert_file, :ca_cert_data, :insecure_skip_verify,
+    attr_reader :ca_cert_file, :ca_cert_data, :insecure_skip_verify, :insecure_skip_hostname_verify,
                 :client_cert_file, :client_key_file, :client_cert_data, :client_key_data
 
     # Initialize TLS configuration
@@ -51,16 +51,19 @@ module Flipt
     # @param ca_cert_file [String, nil] Path to CA certificate file (PEM format)
     # @param ca_cert_data [String, nil] Raw CA certificate content (PEM format)
     # @param insecure_skip_verify [Boolean, nil] Skip certificate verification (development only)
+    # @param insecure_skip_hostname_verify [Boolean, nil] Skip hostname verification 
+    #                                                   while maintaining certificate validation (development only)
     # @param client_cert_file [String, nil] Path to client certificate file (PEM format)
     # @param client_key_file [String, nil] Path to client key file (PEM format)
     # @param client_cert_data [String, nil] Raw client certificate content (PEM format)
     # @param client_key_data [String, nil] Raw client key content (PEM format)
     def initialize(ca_cert_file: nil, ca_cert_data: nil, insecure_skip_verify: nil,
-                   client_cert_file: nil, client_key_file: nil,
+                   insecure_skip_hostname_verify: nil, client_cert_file: nil, client_key_file: nil,
                    client_cert_data: nil, client_key_data: nil)
       @ca_cert_file = ca_cert_file
       @ca_cert_data = ca_cert_data
       @insecure_skip_verify = insecure_skip_verify
+      @insecure_skip_hostname_verify = insecure_skip_hostname_verify
       @client_cert_file = client_cert_file
       @client_key_file = client_key_file
       @client_cert_data = client_cert_data
@@ -73,6 +76,7 @@ module Flipt
     # WARNING: Only use this in development environments
     #
     # @return [TlsConfig] TLS config with certificate verification disabled
+    # @deprecated Use TlsConfig constructor instead
     def self.insecure
       new(insecure_skip_verify: true)
     end
@@ -118,6 +122,7 @@ module Flipt
       hash[:ca_cert_file] = @ca_cert_file if @ca_cert_file
       hash[:ca_cert_data] = @ca_cert_data if @ca_cert_data
       hash[:insecure_skip_verify] = @insecure_skip_verify unless @insecure_skip_verify.nil?
+      hash[:insecure_skip_hostname_verify] = @insecure_skip_hostname_verify unless @insecure_skip_hostname_verify.nil?
       hash[:client_cert_file] = @client_cert_file if @client_cert_file
       hash[:client_key_file] = @client_key_file if @client_key_file
       hash[:client_cert_data] = @client_cert_data if @client_cert_data

--- a/flipt-client-ruby/lib/flipt_client/models.rb
+++ b/flipt-client-ruby/lib/flipt_client/models.rb
@@ -51,7 +51,7 @@ module Flipt
     # @param ca_cert_file [String, nil] Path to CA certificate file (PEM format)
     # @param ca_cert_data [String, nil] Raw CA certificate content (PEM format)
     # @param insecure_skip_verify [Boolean, nil] Skip certificate verification (development only)
-    # @param insecure_skip_hostname_verify [Boolean, nil] Skip hostname verification 
+    # @param insecure_skip_hostname_verify [Boolean, nil] Skip hostname verification
     #                                                   while maintaining certificate validation (development only)
     # @param client_cert_file [String, nil] Path to client certificate file (PEM format)
     # @param client_key_file [String, nil] Path to client key file (PEM format)

--- a/flipt-client-ruby/spec/client_spec.rb
+++ b/flipt-client-ruby/spec/client_spec.rb
@@ -144,34 +144,28 @@ RSpec.describe Flipt::Client do
     describe '#to_h' do
       it 'includes insecure_skip_hostname_verify when set to true' do
         tls_config = Flipt::TlsConfig.new(
-          ca_cert_file: '/path/to/ca.crt',
           insecure_skip_hostname_verify: true
         )
 
         hash = tls_config.to_h
-        expect(hash[:ca_cert_file]).to eq('/path/to/ca.crt')
         expect(hash[:insecure_skip_hostname_verify]).to eq(true)
       end
 
       it 'excludes insecure_skip_hostname_verify when nil' do
         tls_config = Flipt::TlsConfig.new(
-          ca_cert_file: '/path/to/ca.crt',
           insecure_skip_hostname_verify: nil
         )
 
         hash = tls_config.to_h
-        expect(hash[:ca_cert_file]).to eq('/path/to/ca.crt')
         expect(hash).not_to have_key(:insecure_skip_hostname_verify)
       end
 
       it 'includes insecure_skip_hostname_verify when set to false' do
         tls_config = Flipt::TlsConfig.new(
-          ca_cert_file: '/path/to/ca.crt',
           insecure_skip_hostname_verify: false
         )
 
         hash = tls_config.to_h
-        expect(hash[:ca_cert_file]).to eq('/path/to/ca.crt')
         expect(hash[:insecure_skip_hostname_verify]).to eq(false)
       end
     end

--- a/flipt-client-ruby/spec/client_spec.rb
+++ b/flipt-client-ruby/spec/client_spec.rb
@@ -139,4 +139,41 @@ RSpec.describe Flipt::Client do
       end
     end
   end
+
+  describe 'TlsConfig' do
+    describe '#to_h' do
+      it 'includes insecure_skip_hostname_verify when set to true' do
+        tls_config = Flipt::TlsConfig.new(
+          ca_cert_file: '/path/to/ca.crt',
+          insecure_skip_hostname_verify: true
+        )
+
+        hash = tls_config.to_h
+        expect(hash[:ca_cert_file]).to eq('/path/to/ca.crt')
+        expect(hash[:insecure_skip_hostname_verify]).to eq(true)
+      end
+
+      it 'excludes insecure_skip_hostname_verify when nil' do
+        tls_config = Flipt::TlsConfig.new(
+          ca_cert_file: '/path/to/ca.crt',
+          insecure_skip_hostname_verify: nil
+        )
+
+        hash = tls_config.to_h
+        expect(hash[:ca_cert_file]).to eq('/path/to/ca.crt')
+        expect(hash).not_to have_key(:insecure_skip_hostname_verify)
+      end
+
+      it 'includes insecure_skip_hostname_verify when set to false' do
+        tls_config = Flipt::TlsConfig.new(
+          ca_cert_file: '/path/to/ca.crt',
+          insecure_skip_hostname_verify: false
+        )
+
+        hash = tls_config.to_h
+        expect(hash[:ca_cert_file]).to eq('/path/to/ca.crt')
+        expect(hash[:insecure_skip_hostname_verify]).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds `insecure_skip_hostname_verify` support to the Ruby SDK `TlsConfig` class for handling self-signed certificates with hostname mismatches.

- Add `insecure_skip_hostname_verify` field to `TlsConfig` class
- Update Ruby documentation with usage examples
- Add comprehensive RSpec tests for hash serialization
- Follow Ruby naming conventions (snake_case)

## Changes

- **Model Update**: Added `insecure_skip_hostname_verify` parameter to `TlsConfig` class initialization
- **Serialization**: Updated `to_h` method to include the new field when set (excludes when nil)
- **Documentation**: 
  - Updated README with field description and usage example for self-signed certificates
  - Added proper YARD documentation for the parameter
- **Tests**: Added three RSpec tests to verify hash serialization works correctly:
  - Includes field when `true`
  - Excludes field when `nil` 
  - Includes field when `false`

## Usage Example

```ruby
# For self-signed certificates with hostname mismatch
tls_config = Flipt::TlsConfig.new(
  ca_cert_file: '/path/to/ca.pem',
  insecure_skip_hostname_verify: true  # Skip hostname verification only
)

client = Flipt::Client.new(
  url: 'https://flipt.example.com',
  tls_config: tls_config
)
```

## Testing

- Hash serialization tests pass
- Follows Ruby conventions and passes RuboCop
- Proper nil handling in serialization

## References

- Related to #1170
- Matches Java SDK implementation pattern
- FFI engine already supports this field (`flipt-engine-ffi/src/tls.rs:13`)

This is part 2 of 6 for adding `insecure_skip_hostname_verify` support to all FFI-based SDKs.