### PR TITLE
feat(csharp): add InsecureSkipHostnameVerify support to TlsConfig

### DIFF
--- a/flipt-client-csharp/README.md
+++ b/flipt-client-csharp/README.md
@@ -221,6 +221,26 @@ var options = new ClientOptions
 using var client = new FliptClient(options);
 ```
 
+#### Self-Signed Certificates with Hostname Mismatch
+
+```csharp
+// For self-signed certificates with hostname mismatch
+var tlsConfig = new TlsConfig
+{
+    CaCertFile = "/path/to/ca.pem",
+    InsecureSkipHostnameVerify = true  // Skip hostname verification only
+};
+
+var options = new ClientOptions
+{
+    Url = "https://localhost:8443",
+    TlsConfig = tlsConfig,
+    Authentication = new Authentication { ClientToken = "your-token" }
+};
+
+using var client = new FliptClient(options);
+```
+
 #### Development Mode (Insecure)
 
 **⚠️ WARNING: Only use this in development environments!**
@@ -246,6 +266,7 @@ The `TlsConfig` class supports the following properties:
 - `CaCertFile`: Path to custom CA certificate file (PEM format)
 - `CaCertData`: Raw CA certificate content (PEM format) - takes precedence over `CaCertFile`
 - `InsecureSkipVerify`: Skip certificate verification (development only)
+- `InsecureSkipHostnameVerify`: Skip TLS hostname verification (useful for self-signed certificates with hostname mismatches)
 - `ClientCertFile`: Client certificate file for mutual TLS (PEM format)
 - `ClientKeyFile`: Client private key file for mutual TLS (PEM format)
 - `ClientCertData`: Raw client certificate content (PEM format) - takes precedence over `ClientCertFile`

--- a/flipt-client-csharp/src/FliptClient/Models/TlsConfig.cs
+++ b/flipt-client-csharp/src/FliptClient/Models/TlsConfig.cs
@@ -33,6 +33,15 @@ namespace FliptClient.Models
         public bool? InsecureSkipVerify { get; set; }
 
         /// <summary>
+        /// Gets or sets whether to skip TLS hostname verification.
+        /// Allows connections to servers with hostname mismatches (e.g., self-signed certificates).
+        /// The certificate chain is still validated.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("insecure_skip_hostname_verify")]
+        public bool? InsecureSkipHostnameVerify { get; set; }
+
+        /// <summary>
         /// Gets or sets the path to the client certificate file for mutual TLS (PEM format).
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/flipt-client-csharp/tests/FliptClient.Tests/TlsConfigTests.cs
+++ b/flipt-client-csharp/tests/FliptClient.Tests/TlsConfigTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Xunit;
+using FliptClient.Models;
+
+namespace FliptClient.Tests
+{
+    public class TlsConfigTests
+    {
+        [Fact]
+        public void TestInsecureSkipHostnameVerifySerializationWhenTrue()
+        {
+            var tlsConfig = new TlsConfig
+            {
+                InsecureSkipHostnameVerify = true
+            };
+
+            string json = JsonSerializer.Serialize(tlsConfig);
+            Assert.Contains("\"insecure_skip_hostname_verify\":true", json);
+        }
+
+        [Fact]
+        public void TestInsecureSkipHostnameVerifySerializationWhenFalse()
+        {
+            var tlsConfig = new TlsConfig
+            {
+                InsecureSkipHostnameVerify = false
+            };
+
+            string json = JsonSerializer.Serialize(tlsConfig);
+            Assert.Contains("\"insecure_skip_hostname_verify\":false", json);
+        }
+
+        [Fact]
+        public void TestInsecureSkipHostnameVerifySerializationWhenNull()
+        {
+            var tlsConfig = new TlsConfig
+            {
+                InsecureSkipHostnameVerify = null
+            };
+
+            string json = JsonSerializer.Serialize(tlsConfig);
+            Assert.DoesNotContain("insecure_skip_hostname_verify", json);
+        }
+
+        [Fact]
+        public void TestInsecureSkipHostnameVerifyJsonPropertyName()
+        {
+            var tlsConfig = new TlsConfig
+            {
+                InsecureSkipHostnameVerify = true
+            };
+
+            string json = JsonSerializer.Serialize(tlsConfig);
+            
+            // Verify it serializes with correct JSON property name
+            Assert.Contains("\"insecure_skip_hostname_verify\":true", json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `InsecureSkipHostnameVerify` support to the C# SDK `TlsConfig` class for handling self-signed certificates with hostname mismatches.

- Add `InsecureSkipHostnameVerify` property to `TlsConfig` class
- Update README documentation with usage examples
- Add comprehensive unit tests for JSON serialization behavior
- Follow C# naming conventions (PascalCase)

## Changes

- **Model Update**: Added `InsecureSkipHostnameVerify` property to `TlsConfig` class in `src/FliptClient/Models/TlsConfig.cs`
- **Documentation**: Updated README with field description and usage example for self-signed certificates
- **Tests**: Added comprehensive unit tests in `TlsConfigTests.cs` to verify JSON serialization works correctly:
  - Includes field when `true`
  - Excludes field when `null` 
  - Includes field when `false`
  - Verifies correct JSON property name (`"insecure_skip_hostname_verify"`)

## Usage Example

```csharp
// For self-signed certificates with hostname mismatch
var tlsConfig = new TlsConfig
{
    CaCertFile = "/path/to/ca.pem",
    InsecureSkipHostnameVerify = true  // Skip hostname verification only
};

var options = new ClientOptions
{
    Url = "https://localhost:8443",
    TlsConfig = tlsConfig,
    Authentication = new Authentication { ClientToken = "your-token" }
};

using var client = new FliptClient(options);
```

## Testing

- JSON serialization tests pass
- Project builds without errors
- Follows existing TLS configuration patterns

## References

- Related to #1170
- Matches Python (#1190) and Ruby (#1191) SDK implementation patterns
- FFI engine already supports this field (`flipt-engine-ffi/src/tls.rs:13`)

This is part 3 of 6 for adding `InsecureSkipHostnameVerify` support to all FFI-based SDKs.