### PR TITLE
fix(swift): add missing Info.plist and module.modulemap to XCFramework

### DIFF
--- a/package/ffi/sdks/swift.go
+++ b/package/ffi/sdks/swift.go
@@ -75,6 +75,89 @@ func (s *SwiftSDK) Build(ctx context.Context, client *dagger.Client, container *
 				cp /tmp/ext/flipt_engine.h Sources/FliptEngineFFI.xcframework/ios-arm64/Headers;
 				cp /tmp/ext/flipt_engine.h Sources/FliptEngineFFI.xcframework/ios-arm64-simulator/Headers;
 				cp /tmp/ext/flipt_engine.h Sources/FliptEngineFFI.xcframework/macos-arm64/Headers;
+				cat > Sources/FliptEngineFFI.xcframework/Info.plist << 'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<dict>
+			<key>BinaryPath</key>
+			<string>libfliptengine.a</string>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64-simulator</string>
+			<key>LibraryPath</key>
+			<string>libfliptengine.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+		<dict>
+			<key>BinaryPath</key>
+			<string>libfliptengine.a</string>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libfliptengine.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>BinaryPath</key>
+			<string>libfliptengine.a</string>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
+			<string>macos-arm64</string>
+			<key>LibraryPath</key>
+			<string>libfliptengine.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>macos</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>
+PLIST
+				cat > Sources/FliptEngineFFI.xcframework/ios-arm64/Headers/module.modulemap << 'MODULEMAP'
+module FliptEngineFFI {
+  header "flipt_engine.h"
+  export *
+}
+MODULEMAP
+				cat > Sources/FliptEngineFFI.xcframework/ios-arm64-simulator/Headers/module.modulemap << 'MODULEMAP'
+module FliptEngineFFI {
+  header "flipt_engine.h"
+  export *
+}
+MODULEMAP
+				cat > Sources/FliptEngineFFI.xcframework/macos-arm64/Headers/module.modulemap << 'MODULEMAP'
+module FliptEngineFFI {
+  header "flipt_engine.h"
+  export *
+}
+MODULEMAP
 			`, "--", opts.Tag})
 
 	_, err := filtered.Sync(ctx)


### PR DESCRIPTION
## Summary

Re: #1227 

Fixes the Swift SDK SPM installation failure by adding missing XCFramework components that are required for Swift Package Manager to properly recognize and import the framework.

## Problem

Users reported that the Swift SDK cannot be installed via SPM, encountering errors when trying to add the package through Xcode or command line. This is a regression from previous working versions.

## Root Cause

The XCFramework generated by the Swift build process was missing two critical components:

1. **Info.plist** - Root-level descriptor file that tells SPM about available platforms and architectures
2. **module.modulemap** - Files that allow Swift to import C headers as modules

## Solution

Updated the Swift build script (`package/ffi/sdks/swift.go`) to generate:

- Root `Info.plist` with proper platform descriptors for iOS arm64, iOS Simulator arm64, and macOS arm64
- `module.modulemap` files in each platform's Headers directory to expose the C API

## Testing

The fix ensures the generated XCFramework structure matches the working format expected by SPM:

```
FliptEngineFFI.xcframework/
├── Info.plist                     ✅ Now included
├── ios-arm64/
│   ├── Headers/
│   │   ├── flipt_engine.h
│   │   └── module.modulemap       ✅ Now included
│   └── libfliptengine.a
├── ios-arm64-simulator/
│   ├── Headers/
│   │   ├── flipt_engine.h  
│   │   └── module.modulemap       ✅ Now included
│   └── libfliptengine.a
└── macos-arm64/
    ├── Headers/
    │   ├── flipt_engine.h
    │   └── module.modulemap       ✅ Now included
    └── libfliptengine.a
```