### PR TITLE
fix(swift): update Package.swift minimum iOS version to 16.0 for Duration compatibility

### DIFF
--- a/flipt-client-swift/Package.swift
+++ b/flipt-client-swift/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "FliptClient",
-    platforms: [.iOS(.v13), .macOS(.v13)],
+    platforms: [.iOS(.v16), .macOS(.v13)],
     products: [
         .library(
             name: "FliptClient",


### PR DESCRIPTION
## Summary

Fixes #1241 - Swift SDK's Package.swift file version mismatch with Duration type usage.

## Problem

The Swift SDK's Package.swift declared support for iOS 13+, but the code uses Swift's `Duration` type which is only available from iOS 16.0+. This created a compatibility mismatch that prevented users from installing the SDK via SPM.

## Root Cause

The `Duration` type is used in FliptClient constructor parameters:
- `requestTimeout: Duration?` 
- `updateInterval: Duration?`

These parameters access `.components.seconds` which requires iOS 16.0+ availability.

## Solution

Updated the minimum iOS platform requirement in Package.swift from iOS 13.0 to iOS 16.0 to align with Duration type availability.

**Before:**
```swift
platforms: [.iOS(.v13), .macOS(.v13)]
```

**After:**
```swift
platforms: [.iOS(.v16), .macOS(.v13)]
```

## Impact

- Fixes SPM installation failures
- Aligns platform requirements with actual code dependencies  
- Provides better type safety with Duration APIs
- Drops support for iOS 13-15 (released 2019-2021)

## Testing

CI will verify the Swift build succeeds with the updated platform requirements.