### PR TITLE
fix(client-go): update streaming URL and response format for Flipt v2.1.0

### DIFF
--- a/flipt-client-go/client.go
+++ b/flipt-client-go/client.go
@@ -716,6 +716,9 @@ func (c *Client) handleStream(ctx context.Context, r io.ReadCloser) error {
 					// Send the result directly as the payload
 					select {
 					case <-ctx.Done():
+						if ctx.Err() == context.Canceled {
+							return nil
+						}
 						return ctx.Err()
 					case c.snapshotChan <- snapshot{payload: chunk.Result}:
 					}


### PR DESCRIPTION
Fixes the streaming URL and response type for the Go client SDK to work with Flipt v2.1.0, similar to the fixes made in PR #1314 for the FFI engine.

## Changes

1. **URL Path**: Updated from `/internal/v1/evaluation/snapshots?[]namespaces=%s` to `/client/v2/environments/%s/namespaces/%s/stream`

2. **Response Format**: Simplified `streamChunk` struct to expect `{result: <Document>}` format instead of the nested namespaces map

3. **Stream Processing**: Updated to directly use the `result` field as the snapshot payload

## Testing

Please test with Flipt v2.1.0 to ensure streaming functionality works correctly.

Generated with [Claude Code](https://claude.ai/code)