### PR TITLE
chore: bump Go version to 1.25 and Dagger version to 0.18.17

### DIFF
--- a/.github/workflows/package-ffi-sdks.yml
+++ b/.github/workflows/package-ffi-sdks.yml
@@ -28,8 +28,8 @@ env:
   PGP_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
   PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-  GO_VERSION: "1.23"
-  DAGGER_VERSION: "0.17.1"
+  GO_VERSION: "1.25"
+  DAGGER_VERSION: "0.18.17"
 
 jobs:
   build:

--- a/.github/workflows/package-wasm-sdks.yml
+++ b/.github/workflows/package-wasm-sdks.yml
@@ -16,8 +16,8 @@ permissions:
 
 env:
   NPM_API_KEY: ${{ secrets.NPM_API_KEY }}
-  GO_VERSION: "1.23"
-  DAGGER_VERSION: "0.17.1"
+  GO_VERSION: "1.25"
+  DAGGER_VERSION: "0.18.17"
 
 jobs:
   build:

--- a/.github/workflows/test-sdks.yml
+++ b/.github/workflows/test-sdks.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.23"
-  DAGGER_VERSION: "0.17.1"
+  GO_VERSION: "1.25"
+  DAGGER_VERSION: "0.18.17"
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Updates GO_VERSION from 1.23 to 1.25 across all workflow files
- Updates DAGGER_VERSION from 0.17.1 to 0.18.17 across all workflow files

## Files Modified
- `.github/workflows/test-sdks.yml`
- `.github/workflows/package-ffi-sdks.yml`
- `.github/workflows/package-wasm-sdks.yml`

## Test plan
- [ ] Verify workflow files have correct version numbers
- [ ] Confirm CI/CD pipelines work with updated versions