### PR TITLE
chore: upgrade claude action to v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -40,24 +40,22 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Optional: Add custom arguments for Claude
+          claude_args: |
+            --allowed-tools "Bash"
+
+          # Example: Customize model, system prompt, and allowed tools
+          # claude_args: |
+          #   --allowed-tools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          #   --model claude-opus-4-20250514
+          #   --system-prompt "Follow our coding standards"
+          #   --max-turns 10
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
 
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          allowed_tools: "Bash"
-
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
 
           # Optional: Custom environment variables for Claude
           # claude_env: |


### PR DESCRIPTION
## Summary
- Upgraded Claude Code GitHub Action from `@beta` to `@v1`
- Migrated configuration to use `claude_args` parameter format
- Moved `allowed_tools` configuration from workflow input to CLI argument `--allowed-tools`
- Removed deprecated `model` and `custom_instructions` parameters
- Updated comments to reflect new configuration options

## Changes
- Action version: `@beta` → `@v1`
- Configuration now uses CLI-style arguments via `claude_args`
- Active configuration: `--allowed-tools "Bash"`
- Includes example comments for additional configuration options