### PR TITLE
feat(js): introduce evaluation hook

### DIFF
--- a/flipt-client-js/src/browser/index.ts
+++ b/flipt-client-js/src/browser/index.ts
@@ -82,6 +82,7 @@ export class FliptClient extends BaseFliptClient {
     const client = new FliptClient(engine, fetcher);
     client.storeEtag(resp);
     client.errorStrategy = options.errorStrategy;
+    client.hook = options.hook;
     return client;
   }
 }

--- a/flipt-client-js/src/core/types.ts
+++ b/flipt-client-js/src/core/types.ts
@@ -134,6 +134,11 @@ export interface ClientOptions {
    * The strategy to use for errors during refresh snapshot calls. {@link ErrorStrategy}
    */
   errorStrategy?: ErrorStrategy;
+
+  /**
+   * The hook to use for before and after evaluation calls.
+   */
+  hook?: Hook;
 }
 
 /**
@@ -222,6 +227,8 @@ export interface BooleanEvaluationResponse {
   requestDurationMillis: number;
   /** Timestamp when the response was generated. */
   timestamp: string;
+  /** Segments that impacted evaluation. */
+  segmentKeys: string[];
 }
 
 /**
@@ -291,4 +298,24 @@ export class ClientOptionsFactory {
       errorStrategy: ErrorStrategy.Fail
     };
   }
+}
+
+/**
+ * Hook interface for before and after evaluation calls.
+ */
+export interface Hook {
+  /**
+   * before is called before evaluation.
+   */
+  before(data: { flagKey: string }): void;
+  /**
+   * after is called after successful evaluation.
+   */
+  after(data: {
+    flagKey: string;
+    flagType: string;
+    value: string;
+    reason: string;
+    segmentKeys: string[];
+  }): void;
 }

--- a/flipt-client-js/src/node/index.ts
+++ b/flipt-client-js/src/node/index.ts
@@ -90,6 +90,7 @@ export class FliptClient extends BaseFliptClient {
     const client = new FliptClient(engine, fetcher);
     client.storeEtag(resp);
     client.errorStrategy = options.errorStrategy;
+    client.hook = options.hook;
 
     // Setup auto-refresh if interval is provided
     if (options.updateInterval && options.updateInterval > 0) {

--- a/flipt-client-js/src/slim/index.ts
+++ b/flipt-client-js/src/slim/index.ts
@@ -109,6 +109,7 @@ export class FliptClient extends BaseFliptClient {
     const client = new FliptClient(engine, fetcher);
     client.storeEtag(resp);
     client.errorStrategy = options.errorStrategy;
+    client.hook = options.hook;
 
     return client;
   }


### PR DESCRIPTION
This pull request introduces a new "hook" mechanism to the Flipt client, enabling users to inject custom logic before and after flag evaluations. The changes add a `Hook` interface, update the client options to accept hooks, and ensure that hook callbacks are invoked at the appropriate points in the evaluation lifecycle for both boolean and variant flag evaluations, including batch operations. Additionally, the evaluation response types are updated to include segment information.

**API enhancements:**

* Extended `BooleanEvaluationResponse` to include a `segmentKeys` property, providing additional context about which segments impacted the evaluation.