### PR TITLE
feat: add segment_keys to BooleanEvaluationResponse

### DIFF
--- a/flipt-client-csharp/src/FliptClient/Models/Response.cs
+++ b/flipt-client-csharp/src/FliptClient/Models/Response.cs
@@ -114,6 +114,12 @@ public class BooleanEvaluationResponse
     /// </summary>
     [JsonPropertyName("timestamp")]
     public string? Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the segment keys that matched.
+    /// </summary>
+    [JsonPropertyName("segment_keys")]
+    public required List<string> SegmentKeys { get; set; }
 }
 
 /// <summary>

--- a/flipt-client-dart/lib/src/models.dart
+++ b/flipt-client-dart/lib/src/models.dart
@@ -436,12 +436,16 @@ class BooleanEvaluationResponse {
   /// The timestamp of the evaluation.
   final String timestamp;
 
+  /// The segment keys involved in the evaluation.
+  final List<String> segmentKeys;
+
   BooleanEvaluationResponse({
     required this.enabled,
     required this.flagKey,
     required this.reason,
     required this.requestDurationMillis,
     required this.timestamp,
+    required this.segmentKeys,
   });
 
   factory BooleanEvaluationResponse.fromJson(Map<String, dynamic> json) =>

--- a/flipt-client-dart/lib/src/models.g.dart
+++ b/flipt-client-dart/lib/src/models.g.dart
@@ -174,6 +174,9 @@ BooleanEvaluationResponse _$BooleanEvaluationResponseFromJson(
       requestDurationMillis:
           (json['request_duration_millis'] as num).toDouble(),
       timestamp: json['timestamp'] as String,
+      segmentKeys: (json['segment_keys'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$BooleanEvaluationResponseToJson(
@@ -184,6 +187,7 @@ Map<String, dynamic> _$BooleanEvaluationResponseToJson(
       'reason': instance.reason,
       'request_duration_millis': instance.requestDurationMillis,
       'timestamp': instance.timestamp,
+      'segment_keys': instance.segmentKeys,
     };
 
 ErrorEvaluationResponse _$ErrorEvaluationResponseFromJson(

--- a/flipt-client-java/src/main/java/io/flipt/client/models/BooleanEvaluationResponse.java
+++ b/flipt-client-java/src/main/java/io/flipt/client/models/BooleanEvaluationResponse.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
 import lombok.Builder;
+import lombok.Singular;
 import lombok.Value;
 
 @Value
@@ -26,6 +28,10 @@ public class BooleanEvaluationResponse {
 
   @JsonProperty("timestamp")
   String timestamp;
+
+  @JsonProperty("segment_keys")
+  @Singular
+  List<String> segmentKeys;
 
   @lombok.experimental.SuperBuilder
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/flipt-client-kotlin-android/src/main/java/io/flipt/client/models/BooleanEvaluationResponse.kt
+++ b/flipt-client-kotlin-android/src/main/java/io/flipt/client/models/BooleanEvaluationResponse.kt
@@ -10,4 +10,5 @@ data class BooleanEvaluationResponse(
     @SerialName("reason") val reason: String,
     @SerialName("request_duration_millis") val requestDurationMillis: Float,
     @SerialName("timestamp") val timestamp: String,
+    @SerialName("segment_keys") val segmentKeys: List<String>,
 )

--- a/flipt-client-python/flipt_client/models.py
+++ b/flipt-client-python/flipt_client/models.py
@@ -202,6 +202,7 @@ class BooleanEvaluationResponse(BaseModel):
     reason: str  #: Reason for the evaluation result.
     request_duration_millis: float  #: Duration of the request in milliseconds.
     timestamp: str  #: Timestamp of the evaluation.
+    segment_keys: List[str]  #: List of matched segment keys.
 
 
 class ErrorEvaluationResponse(BaseModel):

--- a/flipt-client-swift/Sources/FliptClient/FliptClient.swift
+++ b/flipt-client-swift/Sources/FliptClient/FliptClient.swift
@@ -363,6 +363,7 @@ public struct BooleanEvaluationResponse: Codable {
     public let reason: String
     public let request_duration_millis: Double
     public let timestamp: String
+    public let segment_keys: [String]
 }
 
 public struct ErrorEvaluationResponse: Codable {


### PR DESCRIPTION
Add segment_keys field to BooleanEvaluationResponse across all FFI-based SDKs to
expose matched segment information during boolean flag evaluation.

related flipt-io/flipt#4759