### PR TITLE
correctly return second as ints for update_interval in case of pydantic v1

### DIFF
--- a/flipt-client-python/flipt_client/models.py
+++ b/flipt-client-python/flipt_client/models.py
@@ -158,10 +158,9 @@ class ClientOptions(BaseModel):
 
     else:
         from pydantic import validator
+
         class Config:
-            json_encoders = {
-                timedelta: lambda v: int(v.total_seconds()) if v else None
-            }
+            json_encoders = {timedelta: lambda v: int(v.total_seconds()) if v else None}
 
         @validator("request_timeout", "update_interval", pre=True)
         def parse_timedelta(cls, v):


### PR DESCRIPTION
Minimal reproducible example is when you have pydantic v < 2:
```
from datetime import timedelta
from flipt_client import FliptClient, ClientOptions
opts = ClientOptions(
    update_interval=timedelta(seconds=30),
)
opts.json()
```
Would produce:
```json
{"environment":null,"namespace":null,"url":null,"request_timeout":null,"update_interval":30.0,"authentication":null,"reference":null,"fetch_mode":null,"error_strategy":null,"snapshot":null,"tls_config":null}
```
As you can see `update_interval` is a float, not an integer. It seems that completely resets all the options and the clients starts ignoring all the options. As soon as I remove `update_interval` from from the client options it starts calling the right URL with correct settings I passed.

Turns out that the default serializer from pydantic v1 under the hood does something like this for serialising timedeltas:
```python
>>> timedelta(seconds=30).total_seconds()
30.0
```

However the for pydantic v2 `update_interval` correctly returns `30` as int in this case.

So the solution was either to change the serialization config to apply `int(...)` to timedelta's.
Another option was to modify `json()` function in pydantic v1 case to be:
```pyt
def json(self, *args, **kwargs):
      import json as json_lib
      d = self.dict(*args, **kwargs)
      return json_lib.dumps(d)
```
I went with the least, in my opinion, invasive solution.