### PR TITLE
fix: Use relative tmp directory path in FFI SDK workflow

### DIFF
--- a/.github/workflows/package-ffi-sdks.yml
+++ b/.github/workflows/package-ffi-sdks.yml
@@ -72,5 +72,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          mkdir -p /tmp
+          mkdir -p tmp
           dagger run go run ./package/ffi --sdks=${{ inputs.sdks }} --push=true --tag=${{ inputs.tag }} --engine-tag=${{ inputs.engine-tag }}


### PR DESCRIPTION
## Summary

Fixes the failing FFI SDK deployment by correcting the temporary directory path in the GitHub Actions workflow.

## Problem

The workflow was creating `/tmp` (absolute system path) but the Go code at `package/ffi/main.go:212` exports files to `"tmp"` (relative workspace path). When Dagger tried to access the `tmp` subdirectory in the source directory, it failed with:

```
Directory.directory(path: "tmp"): Directory!
ERROR [0.0s]
! failed to stat file /tmp: lstat /tmp: no such file or directory
```

## Solution

Changed `mkdir -p /tmp` to `mkdir -p tmp` in the workflow to create the directory in the correct location (workspace root) where the Go code expects it.

## References

- Failing run: https://github.com/flipt-io/flipt-client-sdks/actions/runs/18912454894/job/53986688824
- Related commit: 8284111 (which attempted to fix the issue but used wrong path)