### PR TITLE
fix: Read directory after FFI download completes

### DIFF
--- a/package/ffi/main.go
+++ b/package/ffi/main.go
@@ -76,10 +76,6 @@ func run() error {
 
 	defer client.Close()
 
-	dir := client.Host().Directory(".", dagger.HostDirectoryOpts{
-		Exclude: []string{".github/", "package/", "test/", ".git/"},
-	})
-
 	var g errgroup.Group
 
 	for _, s := range builds {
@@ -88,6 +84,11 @@ func run() error {
 			if err := downloadFFI(ctx, client, s); err != nil {
 				return err
 			}
+
+			// Read directory AFTER downloading FFI files so tmp/ is included
+			dir := client.Host().Directory(".", dagger.HostDirectoryOpts{
+				Exclude: []string{".github/", "package/", "test/", ".git/"},
+			})
 
 			container := client.Container(dagger.ContainerOpts{
 				Platform: dagger.Platform("linux/amd64"),


### PR DESCRIPTION
## Summary

Fixes the FFI SDK build failure by reading the directory snapshot AFTER the FFI files are downloaded, not before.

## Problem

The previous fix (#1405) changed the workflow to create `tmp` instead of `/tmp`, but the builds were still failing with:

```
Directory.directory(path: "tmp"): Directory!
ERROR [0.0s]
! failed to stat file /tmp: lstat /tmp: no such file or directory
```

The issue was **timing**:

1. Line 79-81 in `package/ffi/main.go` created a directory snapshot: `dir := client.Host().Directory(".")`
2. Then `downloadFFI()` ran and exported files to "tmp" on the host
3. But `dir` was already a snapshot from step 1, **before tmp was populated**
4. When the SDK tried to access `dir.Directory("tmp")`, it was looking in the old snapshot

## Solution

Moved the directory reading **inside the goroutine, after `downloadFFI()` completes**. Now each build gets a fresh directory snapshot that includes the downloaded tmp/ files.

## Changes

- Removed the global `dir` variable created before the loop
- Added `dir := client.Host().Directory(...)` inside each goroutine after `downloadFFI()` completes
- Added comment explaining why the directory is read after download