### PR TITLE
fix: Use absolute path for Dagger export to fix Python SDK build

### DIFF
--- a/package/ffi/main.go
+++ b/package/ffi/main.go
@@ -170,7 +170,14 @@ func downloadFFI(ctx context.Context, client *dagger.Client, sdk sdks.SDK) error
 
 	packages := sdk.SupportedPlatforms()
 
-	if err := os.RemoveAll("tmp"); err != nil {
+	// Get absolute path for tmp directory to work with Dagger 0.18.17+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+	tmpDir := fmt.Sprintf("%s/tmp", cwd)
+
+	if err := os.RemoveAll(tmpDir); err != nil {
 		return fmt.Errorf("failed to remove tmp directory: %w", err)
 	}
 
@@ -206,7 +213,7 @@ func downloadFFI(ctx context.Context, client *dagger.Client, sdk sdks.SDK) error
 		if _, err := container.
 			WithExec(cmd).
 			Directory("/out").
-			Export(ctx, "tmp"); err != nil {
+			Export(ctx, tmpDir); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the Python SDK (and all FFI SDK) build failures that started occurring after upgrading to Dagger 0.18.17.

## Problem

The build was failing with:
```
failed to stat file /tmp: lstat /tmp: no such file or directory
```

This error occurred when Dagger tried to export the downloaded FFI files to the host.

## Root Cause

Dagger 0.18.17 (upgraded in commit e08d189) introduced a breaking change in how it handles relative paths in the `Export()` function:

- **Dagger 0.17.1** (last working): Correctly resolved `"tmp"` as relative path `./tmp`
- **Dagger 0.18.17** (current): Incorrectly resolves `"tmp"` as absolute path `/tmp`

## Solution

Changed the export path from a relative path to an absolute path by:
1. Getting the current working directory with `os.Getwd()`
2. Constructing the full path: `tmpDir := fmt.Sprintf("%s/tmp", cwd)`
3. Using `tmpDir` instead of `"tmp"` in the `Export()` call

This ensures Dagger 0.18.17+ correctly exports to the intended location.

## Changes

- Reverted directory reading to before goroutine execution (restoring the working pattern from September)
- Modified `downloadFFI()` to use absolute path for the export destination

## Testing

This should fix all FFI SDK builds including the failing Python SDK Windows build.