### PR TITLE
fix: Pass tmp directory as absolute path to all SDK builds (Dagger 0.18.17 compatibility)

### DIFF
--- a/package/ffi/main.go
+++ b/package/ffi/main.go
@@ -80,6 +80,14 @@ func run() error {
 		Exclude: []string{".github/", "package/", "test/", ".git/"},
 	})
 
+	// Get absolute path for tmp directory to work with Dagger 0.18.17+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+	tmpPath := fmt.Sprintf("%s/tmp", cwd)
+	tmpDir := client.Host().Directory(tmpPath)
+
 	var g errgroup.Group
 
 	for _, s := range builds {
@@ -92,7 +100,7 @@ func run() error {
 				Platform: dagger.Platform("linux/amd64"),
 			})
 
-			return s.Build(ctx, client, container, dir, sdks.BuildOpts{
+			return s.Build(ctx, client, container, dir, tmpDir, sdks.BuildOpts{
 				Tag:       tag,
 				EngineTag: engineTag,
 				Push:      push,

--- a/package/ffi/sdks/android.go
+++ b/package/ffi/sdks/android.go
@@ -21,7 +21,7 @@ func (s *AndroidSDK) SupportedPlatforms() []platform.Platform {
 	}
 }
 
-func (s *AndroidSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, opts BuildOpts) error {
+func (s *AndroidSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, tmpDirectory *dagger.Directory, opts BuildOpts) error {
 	// the directory structure of the tmp directory is as follows:
 	// tmp/android_x86_64/
 	// tmp/android_aarch64/

--- a/package/ffi/sdks/csharp.go
+++ b/package/ffi/sdks/csharp.go
@@ -12,13 +12,13 @@ type CSharpSDK struct {
 	BaseSDK
 }
 
-func (s *CSharpSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, opts BuildOpts) error {
+func (s *CSharpSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, tmpDirectory *dagger.Directory, opts BuildOpts) error {
 	container = container.From("mcr.microsoft.com/dotnet/sdk:8.0").
 		WithWorkdir("/src").
 		WithDirectory("/src", hostDirectory.Directory("flipt-client-csharp"), dagger.ContainerWithDirectoryOpts{
 			Exclude: []string{".gitignore", "obj/", "bin/"},
 		}).
-		WithDirectory("/src/src/FliptClient/ext/ffi", hostDirectory.Directory("tmp"), dagger.ContainerWithDirectoryOpts{
+		WithDirectory("/src/src/FliptClient/ext/ffi", tmpDirectory, dagger.ContainerWithDirectoryOpts{
 			Include: dynamicInclude,
 		}).
 		WithExec(args("dotnet restore")).

--- a/package/ffi/sdks/dart.go
+++ b/package/ffi/sdks/dart.go
@@ -24,7 +24,7 @@ func (s *DartSDK) SupportedPlatforms() []platform.Platform {
 	}
 }
 
-func (s *DartSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, opts BuildOpts) error {
+func (s *DartSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, tmpDirectory *dagger.Directory, opts BuildOpts) error {
 	// we need to download the FliptEngineFFI.xcframework.tar.gz file from the release and extract it into the tmp directory to support the iOS SDK
 	var (
 		url = fmt.Sprintf("https://github.com/flipt-io/flipt-client-sdks/releases/download/flipt-engine-ffi-%s/%s.%s", opts.EngineTag, "FliptEngineFFI.xcframework", "tar.gz")

--- a/package/ffi/sdks/java.go
+++ b/package/ffi/sdks/java.go
@@ -13,7 +13,7 @@ type JavaSDK struct {
 	BaseSDK
 }
 
-func (s *JavaSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, opts BuildOpts) error {
+func (s *JavaSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, tmpDirectory *dagger.Directory, opts BuildOpts) error {
 	// the directory structure of the tmp directory is as follows:
 	// tmp/linux_x86_64/
 	// tmp/linux_aarch64/

--- a/package/ffi/sdks/python.go
+++ b/package/ffi/sdks/python.go
@@ -12,11 +12,11 @@ type PythonSDK struct {
 	BaseSDK
 }
 
-func (s *PythonSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, opts BuildOpts) error {
+func (s *PythonSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, tmpDirectory *dagger.Directory, opts BuildOpts) error {
 	container = container.From("python:3.11-bookworm").
 		WithExec(args("pip install poetry==1.7.0")).
 		WithDirectory("/src", hostDirectory.Directory("flipt-client-python")).
-		WithDirectory("/src/ext", hostDirectory.Directory("tmp"), dagger.ContainerWithDirectoryOpts{
+		WithDirectory("/src/ext", tmpDirectory, dagger.ContainerWithDirectoryOpts{
 			Include: dynamicInclude,
 		}).
 		WithFile("/src/ext/flipt_engine.h", hostDirectory.File("flipt-engine-ffi/include/flipt_engine.h")).

--- a/package/ffi/sdks/ruby.go
+++ b/package/ffi/sdks/ruby.go
@@ -12,11 +12,11 @@ type RubySDK struct {
 	BaseSDK
 }
 
-func (s *RubySDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, opts BuildOpts) error {
+func (s *RubySDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, tmpDirectory *dagger.Directory, opts BuildOpts) error {
 	container = container.From("ruby:3.1-bookworm").
 		WithWorkdir("/src").
 		WithDirectory("/src", hostDirectory.Directory("flipt-client-ruby")).
-		WithDirectory("/src/lib/ext", hostDirectory.Directory("tmp"), dagger.ContainerWithDirectoryOpts{
+		WithDirectory("/src/lib/ext", tmpDirectory, dagger.ContainerWithDirectoryOpts{
 			Include: dynamicInclude,
 		}).
 		WithFile("/src/lib/ext/flipt_engine.h", hostDirectory.File("flipt-engine-ffi/include/flipt_engine.h")).

--- a/package/ffi/sdks/sdk.go
+++ b/package/ffi/sdks/sdk.go
@@ -24,7 +24,7 @@ type BuildOpts struct {
 
 type SDK interface {
 	SupportedPlatforms() []platform.Platform
-	Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, opts BuildOpts) error
+	Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, tmpDirectory *dagger.Directory, opts BuildOpts) error
 }
 
 type BaseSDK struct{}

--- a/package/ffi/sdks/swift.go
+++ b/package/ffi/sdks/swift.go
@@ -24,7 +24,7 @@ func (s *SwiftSDK) SupportedPlatforms() []platform.Platform {
 	}
 }
 
-func (s *SwiftSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, opts BuildOpts) error {
+func (s *SwiftSDK) Build(ctx context.Context, client *dagger.Client, container *dagger.Container, hostDirectory *dagger.Directory, tmpDirectory *dagger.Directory, opts BuildOpts) error {
 	pat := os.Getenv("GITHUB_TOKEN")
 	if pat == "" && opts.Push {
 		return errors.New("GITHUB_TOKEN environment variable must be set")
@@ -58,7 +58,7 @@ func (s *SwiftSDK) Build(ctx context.Context, client *dagger.Client, container *
 	repository := git.
 		WithExec(args("git clone https://github.com/flipt-io/flipt-client-sdks.git /src")).
 		WithWorkdir("/src").
-		WithDirectory("/tmp/ext", hostDirectory.Directory("tmp")).
+		WithDirectory("/tmp/ext", tmpDirectory).
 		WithFile("/tmp/ext/flipt_engine.h", hostDirectory.File("flipt-engine-ffi/include/flipt_engine.h"))
 
 	filtered := repository.


### PR DESCRIPTION
## Summary

Fixes the remaining Python SDK (and all FFI SDK) build failures caused by Dagger 0.18.17's breaking change in handling relative paths.

## Problem

After PR #1407, the export was fixed but builds were still failing with:
```
input: host.directory.directory failed to stat file /tmp: lstat /tmp: no such file or directory
```

This was happening when SDK builds tried to access `hostDirectory.Directory("tmp")`.

## Root Cause

Dagger 0.18.17 has a breaking change where **any** relative path reference to "tmp" is incorrectly resolved as the absolute system path "/tmp" instead of the relative path "./tmp".

The issue occurred in multiple places:
- `python.go:19` - `hostDirectory.Directory("tmp")`
- `ruby.go:19` - `hostDirectory.Directory("tmp")`  
- `csharp.go:21` - `hostDirectory.Directory("tmp")`
- `swift.go:61` - `hostDirectory.Directory("tmp")`

## Solution

1. **Create tmp Directory object with absolute path in main.go**:
   ```go
   cwd, err := os.Getwd()
   tmpPath := fmt.Sprintf("%s/tmp", cwd)
   tmpDir := client.Host().Directory(tmpPath)
   ```

2. **Update SDK interface** to accept `tmpDirectory *dagger.Directory` as a separate parameter

3. **Update all SDK implementations** to use the passed `tmpDirectory` parameter instead of calling `hostDirectory.Directory("tmp")`

This ensures Dagger 0.18.17+ correctly resolves the tmp directory path in all contexts.

## Changes

- Modified SDK interface in `sdk.go`
- Updated `main.go` to create and pass tmp Directory
- Updated all 7 SDK implementations (Python, Ruby, C#, Swift, Java, Dart, Android)

## Testing

This should finally fix all FFI SDK builds including the Windows build that was originally reported.