### PR TITLE
chore: bump flipt-client-js dep for flipt-client-react

### DIFF
--- a/flipt-client-react/package-lock.json
+++ b/flipt-client-react/package-lock.json
@@ -44,7 +44,7 @@
         "typescript": "^5.6.0"
       },
       "peerDependencies": {
-        "@flipt-io/flipt-client-js": "^0.3.0",
+        "@flipt-io/flipt-client-js": "^0.4.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/@flipt-io/flipt-client-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@flipt-io/flipt-client-js/-/flipt-client-js-0.3.0.tgz",
-      "integrity": "sha512-cdM4xAQGz01zVY0I+VGqAhwRu9qQzn/h+sac9fIqJo3xmNveLm45yo1tADIutbkWox6e0Ucz9iy0MN+FFAhJpw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@flipt-io/flipt-client-js/-/flipt-client-js-0.4.0.tgz",
+      "integrity": "sha512-2D0kqr9saOW845QSt/eNe56GIEKVvnM91szs4QjG69jlb0he2DMzA2yjM5wQ1DbL3aRrw5CBVi/PG7hhs0gRvw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/flipt-client-react/package.json
+++ b/flipt-client-react/package.json
@@ -66,7 +66,7 @@
     "typescript": "^5.6.0"
   },
   "peerDependencies": {
-    "@flipt-io/flipt-client-js": "^0.3.0",
+    "@flipt-io/flipt-client-js": "^0.4.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },


### PR DESCRIPTION
This pull request updates the `@flipt-io/flipt-client-js` dependency in the `flipt-client-react` package from version `^0.3.0` to `^0.4.0`. This ensures compatibility with the latest features and fixes from the client library.

Dependency updates:

* Updated the `@flipt-io/flipt-client-js` peer dependency version in `package.json` from `^0.3.0` to `^0.4.0`.
* Updated the `@flipt-io/flipt-client-js` version and its associated metadata in `package-lock.json` to `0.4.0`. [[1]](diffhunk://#diff-98d4bc2e0f194058c31fa47ba71b4cec2918d07561f7cfdc4c76ddb0add28373L47-R47) [[2]](diffhunk://#diff-98d4bc2e0f194058c31fa47ba71b4cec2918d07561f7cfdc4c76ddb0add28373L766-R768)