### PR TITLE
chore: update Android build script to use 16kb page size

### DIFF
--- a/.github/workflows/package-ffi-engine-android.yml
+++ b/.github/workflows/package-ffi-engine-android.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "flipt-engine-ffi/**"
       - "flipt-evaluation/**"
+      - ".github/workflows/package-ffi-engine-android.yml"
   push:
     tags: ["flipt-engine-ffi-v**"]
 


### PR DESCRIPTION
Android is requiring developers to update their apps to support 16KB page size in the near future. I've updated the build script for libfliptengine.so to use 16KB page size. 

https://developer.android.com/guide/practices/page-sizes

I've tested this myself by running the workflow and inserting the updated libfliptengine.so into my flutter app before building and can confirm that it meets the android 16KB page size requirements.