### PR TITLE
chore: bump flipt engine ffi to 0.19.2

### DIFF
--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-engine-ffi"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"


### PR DESCRIPTION
with fix from #1482 