### PR TITLE
fix(go): allow WASM files in vendored builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ staging
 .claude
 .cursor
 CLAUDE.local.md
+
+# Address issue #1595
+flipt-client-go/ext/*.wasm

--- a/flipt-client-go/.gitignore
+++ b/flipt-client-go/.gitignore
@@ -8,7 +8,6 @@
 *.so
 *.a
 *.dylib
-*.wasm
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
closes #1595
