### PR TITLE
feat(ffi): reconnect streaming on auth credential rotation

### DIFF
--- a/flipt-engine-ffi/src/http.rs
+++ b/flipt-engine-ffi/src/http.rs
@@ -101,6 +101,10 @@ pub struct HTTPFetcher {
     namespace: String,
     auth_receiver: watch::Receiver<HeaderMap>,
     auth_sender: Option<watch::Sender<HeaderMap>>,
+    /// Signals the streaming loop to drop its current connection and reconnect,
+    /// picking up rotated credentials. A streaming request's headers are fixed
+    /// at connect time, so new credentials only take effect on a new connection.
+    reconnect_notify: Arc<Notify>,
     etag: Option<String>,
     reference: Option<String>,
     update_interval: Duration,
@@ -116,12 +120,33 @@ impl Clone for HTTPFetcher {
             namespace: self.namespace.clone(),
             auth_receiver: self.auth_receiver.clone(),
             auth_sender: None,
+            reconnect_notify: self.reconnect_notify.clone(),
             etag: self.etag.clone(),
             reference: self.reference.clone(),
             update_interval: self.update_interval,
             mode: self.mode.clone(),
         }
     }
+}
+
+/// Stores rotated auth headers and, if they changed, signals the streaming loop
+/// to reconnect with the new credentials. Returns whether the value changed so a
+/// no-op rotation doesn't needlessly drop the streaming connection. Errors only
+/// when the watch channel has no live receivers (the fetcher has shut down).
+pub(crate) fn rotate_auth_headers(
+    sender: &watch::Sender<HeaderMap>,
+    reconnect_notify: &Notify,
+    headers: HeaderMap,
+) -> Result<bool, Error> {
+    if *sender.borrow() == headers {
+        return Ok(false);
+    }
+    sender
+        .send(headers)
+        .map_err(|_| Error::Internal("auth channel closed".to_string()))?;
+    log::debug!("auth headers rotated; signaling streaming reconnect");
+    reconnect_notify.notify_one();
+    Ok(true)
 }
 
 pub struct HTTPFetcherBuilder {
@@ -306,6 +331,7 @@ impl HTTPFetcherBuilder {
                 .build(),
             auth_receiver,
             auth_sender: Some(auth_sender),
+            reconnect_notify: Arc::new(Notify::new()),
             etag: None,
             reference: self.reference,
             update_interval: self.update_interval,
@@ -320,6 +346,12 @@ impl HTTPFetcher {
     /// Take the auth sender out of the fetcher. Returns `None` if already taken or if this is a clone.
     pub fn take_auth_sender(&mut self) -> Option<watch::Sender<HeaderMap>> {
         self.auth_sender.take()
+    }
+
+    /// Returns a handle to the reconnect notifier. Signalling it (via
+    /// `rotate_auth_headers`) makes an active streaming session reconnect.
+    pub fn reconnect_notify(&self) -> Arc<Notify> {
+        self.reconnect_notify.clone()
     }
 
     /// Start the fetcher and return a channel to receive updates on the snapshot changes
@@ -371,7 +403,9 @@ impl HTTPFetcher {
                             log::warn!("error fetching streaming: {e}");
                             break;
                         }
-                        // If handle_streaming returns without error, the stream was closed or stop_signal was set
+                        // handle_streaming returns Ok when the stream closed, a stop
+                        // was requested, or credentials were rotated; loop to
+                        // reconnect unless we're actually stopping.
                         if stop_signal.load(Ordering::Relaxed) {
                             return;
                         }
@@ -531,6 +565,9 @@ impl HTTPFetcher {
         stop_signal: &Arc<AtomicBool>,
         stop_notify: &Arc<Notify>,
     ) -> Result<(), Error> {
+        // Cloned before the connect so the reconnect future doesn't borrow
+        // `self` while the read loop holds the response stream.
+        let reconnect_notify = self.reconnect_notify.clone();
         let stream_result = self.fetch_stream().await;
 
         match stream_result {
@@ -563,6 +600,11 @@ impl HTTPFetcher {
                     let stop_notified = stop_notify.notified();
                     tokio::pin!(stop_notified);
 
+                    // `notify_one` stores a permit, so a rotation that fires
+                    // between sessions is still observed by this fresh future.
+                    let reconnect_notified = reconnect_notify.notified();
+                    tokio::pin!(reconnect_notified);
+
                     tokio::select! {
                         value = stream.next() => {
                             match value {
@@ -580,6 +622,10 @@ impl HTTPFetcher {
                             }
                         }
                         _ = &mut stop_notified => {
+                            return Ok(());
+                        }
+                        _ = &mut reconnect_notified => {
+                            log::debug!("auth credentials rotated; reconnecting stream");
                             return Ok(());
                         }
                     }
@@ -1021,5 +1067,199 @@ mod tests {
         let result = fetcher.fetch().await;
         assert!(result.is_ok());
         mock_with_auth.assert();
+    }
+
+    /// Writes one snapshot frame, then holds the connection open by writing
+    /// non-newline filler bytes every 25ms until the client disconnects.
+    /// LinesCodec buffers the filler without producing frames, so the client
+    /// sees a single snapshot and an idle stream — the shape of a real SSE
+    /// endpoint between pushes. The poll-for-disconnect loop frees the mock
+    /// server thread as soon as the client goes away, so other mocks can run.
+    fn write_snapshot_then_hold(w: &mut dyn std::io::Write) -> std::io::Result<()> {
+        w.write_all(b"{\"result\":{\"namespace\": {\"key\": \"default\"}, \"flags\":[]}}\n")?;
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            if w.write_all(b" ").is_err() {
+                return Ok(());
+            }
+        }
+    }
+
+    #[test]
+    fn test_deserialize_authentication_none_string() {
+        // Externally-tagged enum with rename_all="snake_case": the unit variant
+        // None is the bare JSON string "none". `{}` is not a valid serialization
+        // and must fail.
+        let none: Authentication = serde_json::from_str("\"none\"").unwrap();
+        assert_eq!(none, Authentication::None);
+        assert!(serde_json::from_str::<Authentication>("{}").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_auth_update_to_none_clears_authorization() {
+        let mut server = Server::new_async().await;
+
+        let mock_with_auth = server
+            .mock("GET", "/internal/v1/evaluation/snapshot/namespace/default")
+            .match_header("authorization", "Bearer initial")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"namespace": {"key": "default"}, "flags":[]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let url = server.url();
+        let mut fetcher = HTTPFetcherBuilder::new(&url)
+            .authentication(Authentication::ClientToken("initial".into()))
+            .build()
+            .unwrap();
+        let sender = fetcher.take_auth_sender().expect("sender present");
+        let reconnect_notify = fetcher.reconnect_notify();
+
+        assert!(fetcher.fetch().await.is_ok());
+        mock_with_auth.assert();
+
+        // Rotate to Authentication::None — the resulting empty HeaderMap should
+        // drop the prior Authorization header on subsequent requests.
+        let cleared = HeaderMap::from(Authentication::None);
+        assert!(super::rotate_auth_headers(&sender, &reconnect_notify, cleared).unwrap());
+
+        let mock_no_auth = server
+            .mock("GET", "/internal/v1/evaluation/snapshot/namespace/default")
+            .match_header("authorization", Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"namespace": {"key": "default"}, "flags":[]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        assert!(fetcher.fetch().await.is_ok());
+        mock_no_auth.assert();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_streaming_reconnects_on_auth_update() {
+        let mut server = Server::new_async().await;
+
+        let mock_old = server
+            .mock(
+                "GET",
+                "/client/v2/environments/default/namespaces/default/stream",
+            )
+            .match_header("authorization", "Bearer old")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_chunked_body(write_snapshot_then_hold)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mock_new = server
+            .mock(
+                "GET",
+                "/client/v2/environments/default/namespaces/default/stream",
+            )
+            .match_header("authorization", "Bearer new")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_chunked_body(write_snapshot_then_hold)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let url = server.url();
+        let mut fetcher = HTTPFetcherBuilder::new(&url)
+            .authentication(Authentication::ClientToken("old".into()))
+            .mode(FetchMode::Streaming)
+            .build()
+            .unwrap();
+
+        let auth_sender = fetcher.take_auth_sender().expect("sender present");
+        let reconnect_notify = fetcher.reconnect_notify();
+
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_notify = Arc::new(Notify::new());
+        let mut rx = fetcher.start(stop_signal.clone(), stop_notify.clone());
+
+        // First snapshot with old auth.
+        let first = tokio::time::timeout(std::time::Duration::from_secs(3), rx.recv())
+            .await
+            .expect("first snapshot timed out")
+            .expect("channel closed")
+            .expect("snapshot error");
+        assert_eq!("default", first.namespace.key);
+
+        // Rotate credentials and signal reconnect.
+        let new_headers = HeaderMap::from(Authentication::ClientToken("new".into()));
+        assert!(super::rotate_auth_headers(&auth_sender, &reconnect_notify, new_headers).unwrap());
+
+        // Second snapshot must come from the new-auth connection.
+        let second = tokio::time::timeout(std::time::Duration::from_secs(3), rx.recv())
+            .await
+            .expect("second snapshot timed out")
+            .expect("channel closed")
+            .expect("snapshot error");
+        assert_eq!("default", second.namespace.key);
+
+        stop_signal.store(true, Ordering::Relaxed);
+        stop_notify.notify_waiters();
+
+        mock_old.assert_async().await;
+        mock_new.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_streaming_skips_reconnect_when_auth_unchanged() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock(
+                "GET",
+                "/client/v2/environments/default/namespaces/default/stream",
+            )
+            .match_header("authorization", "Bearer token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_chunked_body(write_snapshot_then_hold)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let url = server.url();
+        let mut fetcher = HTTPFetcherBuilder::new(&url)
+            .authentication(Authentication::ClientToken("token".into()))
+            .mode(FetchMode::Streaming)
+            .build()
+            .unwrap();
+
+        let auth_sender = fetcher.take_auth_sender().unwrap();
+        let reconnect_notify = fetcher.reconnect_notify();
+
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_notify = Arc::new(Notify::new());
+        let mut rx = fetcher.start(stop_signal.clone(), stop_notify.clone());
+
+        tokio::time::timeout(std::time::Duration::from_secs(3), rx.recv())
+            .await
+            .expect("snapshot timed out")
+            .expect("channel closed")
+            .expect("snapshot error");
+
+        // Identical headers: rotate_auth_headers must short-circuit without
+        // notifying, so no second request lands (mock is .expect(1)).
+        let same_headers = HeaderMap::from(Authentication::ClientToken("token".into()));
+        assert!(
+            !super::rotate_auth_headers(&auth_sender, &reconnect_notify, same_headers).unwrap(),
+            "rotate_auth_headers must return Ok(false) for identical headers"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+        stop_signal.store(true, Ordering::Relaxed);
+        stop_notify.notify_waiters();
+
+        mock.assert_async().await;
     }
 }

--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -127,6 +127,7 @@ pub struct Engine {
     fetcher_handle: Option<tokio::task::JoinHandle<()>>,
     stop_notify: Arc<Notify>,
     auth_sender: Option<watch::Sender<HeaderMap>>,
+    reconnect_notify: Arc<Notify>,
 }
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
@@ -165,6 +166,7 @@ impl Engine {
         initial_snapshot: snapshot::Snapshot,
     ) -> Self {
         let auth_sender = fetcher.take_auth_sender();
+        let reconnect_notify = fetcher.reconnect_notify();
         let stop_signal = Arc::new(AtomicBool::new(false));
         let stop_signal_clone = stop_signal.clone();
 
@@ -232,6 +234,7 @@ impl Engine {
             fetcher_handle: Some(fetcher_handle),
             stop_notify,
             auth_sender,
+            reconnect_notify,
         }
     }
 
@@ -914,11 +917,11 @@ unsafe extern "C" fn _update_authentication(
     let header_map = HeaderMap::from(auth);
 
     match &e.auth_sender {
-        Some(sender) => match sender.send(header_map) {
+        // Rotate the stored headers and, in streaming mode, signal a reconnect
+        // so the new credentials take effect without restarting the engine.
+        Some(sender) => match http::rotate_auth_headers(sender, &e.reconnect_notify, header_map) {
             Ok(_) => result_to_json_ptr(Ok::<(), Error>(())),
-            Err(_) => result_to_json_ptr::<(), Error>(Err(Error::Internal(
-                "auth channel closed".to_string(),
-            ))),
+            Err(err) => result_to_json_ptr::<(), Error>(Err(err)),
         },
         None => result_to_json_ptr::<(), Error>(Err(Error::Internal(
             "no auth sender available".to_string(),
@@ -1019,10 +1022,7 @@ mod tests {
     fn test_engine_opts_with_invalid_snapshot() {
         let json = r#"{\"url\":\"http://localhost:8080\",\"snapshot\":\"eyJmb28iOiJiYXIifQ==\",\"error_strategy\":\"fallback\"}"#;
 
-        match serde_json::from_str::<EngineOpts>(json) {
-            Ok(_) => panic!("Expected error, but got Ok"),
-            Err(_) => (),
-        }
+        assert!(serde_json::from_str::<EngineOpts>(json).is_err());
     }
 
     #[test]
@@ -1270,5 +1270,149 @@ mod tests {
             _destroy_string(result_ptr as *mut c_char);
             _destroy_engine(engine_ptr);
         }
+    }
+
+    #[test]
+    fn test_update_authentication_clears_with_none() {
+        // Authentication::None deserializes from the bare string "none";
+        // updating to it must succeed and clear the Authorization header.
+        unsafe {
+            let opts = CString::new(
+                r#"{"url":"http://localhost:1","error_strategy":"fallback","update_interval":9999,"authentication":{"client_token":"old"}}"#,
+            )
+            .unwrap();
+            let engine_ptr = _initialize_engine(opts.as_ptr());
+            assert!(!engine_ptr.is_null());
+
+            let auth_json = CString::new(r#""none""#).unwrap();
+            let result_ptr = _update_authentication(engine_ptr, auth_json.as_ptr());
+            assert!(!result_ptr.is_null());
+
+            let result_str = CStr::from_ptr(result_ptr).to_str().unwrap();
+            assert!(
+                result_str.contains("success"),
+                "Expected success response, got: {}",
+                result_str
+            );
+
+            _destroy_string(result_ptr as *mut c_char);
+            _destroy_engine(engine_ptr);
+        }
+    }
+
+    #[test]
+    fn test_update_authentication_rejects_empty_object() {
+        // `{}` is not a valid serialization of the externally-tagged
+        // Authentication enum and must error rather than be treated as None.
+        unsafe {
+            let opts = CString::new(
+                r#"{"url":"http://localhost:1","error_strategy":"fallback","update_interval":9999}"#,
+            )
+            .unwrap();
+            let engine_ptr = _initialize_engine(opts.as_ptr());
+            assert!(!engine_ptr.is_null());
+
+            let auth_json = CString::new("{}").unwrap();
+            let result_ptr = _update_authentication(engine_ptr, auth_json.as_ptr());
+            assert!(!result_ptr.is_null());
+
+            let result_str = CStr::from_ptr(result_ptr).to_str().unwrap();
+            assert!(
+                result_str.contains("failure") && result_str.contains("invalid auth JSON"),
+                "Expected invalid-auth-JSON failure, got: {}",
+                result_str
+            );
+
+            _destroy_string(result_ptr as *mut c_char);
+            _destroy_engine(engine_ptr);
+        }
+    }
+
+    /// Emits one snapshot frame then holds the connection open with non-newline
+    /// filler until the client disconnects — a long-lived streaming response.
+    fn write_snapshot_then_hold(w: &mut dyn std::io::Write) -> std::io::Result<()> {
+        w.write_all(b"{\"result\":{\"namespace\": {\"key\": \"default\"}, \"flags\":[]}}\n")?;
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            if w.write_all(b" ").is_err() {
+                return Ok(());
+            }
+        }
+    }
+
+    #[test]
+    fn test_streaming_auth_rotation_through_ffi() {
+        // Drives the full FFI auth-rotation path against a real HTTP server:
+        // _initialize_engine -> initial snapshot fetch -> streaming session with
+        // old auth -> _update_authentication -> reconnect with new auth. Stubs
+        // both the snapshot and stream endpoints because _initialize_engine
+        // performs a synchronous initial_fetch().
+        let mut server = mockito::Server::new();
+
+        let snapshot_mock = server
+            .mock("GET", "/internal/v1/evaluation/snapshot/namespace/default")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"namespace": {"key": "default"}, "flags":[]}"#)
+            .expect_at_least(1)
+            .create();
+
+        let stream_old = server
+            .mock(
+                "GET",
+                "/client/v2/environments/default/namespaces/default/stream",
+            )
+            .match_header("authorization", "Bearer old")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_chunked_body(write_snapshot_then_hold)
+            .expect(1)
+            .create();
+
+        let stream_new = server
+            .mock(
+                "GET",
+                "/client/v2/environments/default/namespaces/default/stream",
+            )
+            .match_header("authorization", "Bearer new")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_chunked_body(write_snapshot_then_hold)
+            .expect_at_least(1)
+            .create();
+
+        let opts_json = format!(
+            r#"{{"url":"{}","error_strategy":"fallback","update_interval":9999,"fetch_mode":"streaming","authentication":{{"client_token":"old"}}}}"#,
+            server.url()
+        );
+
+        unsafe {
+            let opts = CString::new(opts_json).unwrap();
+            let engine_ptr = _initialize_engine(opts.as_ptr());
+            assert!(!engine_ptr.is_null());
+
+            // Wait for the streaming task to dial with old auth.
+            std::thread::sleep(std::time::Duration::from_millis(500));
+
+            let auth_json = CString::new(r#"{"client_token":"new"}"#).unwrap();
+            let result_ptr = _update_authentication(engine_ptr, auth_json.as_ptr());
+            assert!(!result_ptr.is_null());
+            let result_str = CStr::from_ptr(result_ptr).to_str().unwrap();
+            assert!(
+                result_str.contains("success"),
+                "auth update should succeed, got: {}",
+                result_str
+            );
+            _destroy_string(result_ptr as *mut c_char);
+
+            // Wait for reconnect with the new credentials.
+            std::thread::sleep(std::time::Duration::from_millis(1000));
+
+            _destroy_engine(engine_ptr);
+        }
+
+        snapshot_mock.assert();
+        stream_old.assert();
+        stream_new.assert();
     }
 }


### PR DESCRIPTION
## Summary

A streaming request fixes its `Authorization` header at connect time, so a credential rotated via `update_authentication` never reaches an in-flight stream. This adds a reconnect signal so streaming mode applies rotated credentials without restarting the engine.

- `update_authentication` writes the new headers to the existing auth `watch` channel (as before) and, if they changed, fires a `reconnect_notify`.
- The streaming read loop selects on `reconnect_notify` alongside the existing stop signal — the same `Notify` + `select!` idiom #1482 introduced for shutdown. On signal it drops the connection and reconnects; `build_headers()` then supplies the new credentials.
- A no-op rotation (unchanged headers) skips the signal, so a redundant refresh doesn't needlessly drop the connection.

Polling already applied rotated credentials on its next fetch; this closes the streaming gap left by the dynamic-auth work in #1608.

## Scope

Deliberately minimal — only what streaming auth refresh requires (~390 lines, mostly tests). No retry/backoff overhaul, cancellable-connect, or liveness flag; those are independent hardening concerns and out of scope here.

## Test plan
- [x] `cargo test -p flipt-engine-ffi` — 39 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- New tests: streaming reconnects on rotation, skips reconnect when auth unchanged, clears auth via `"none"`, rejects `{}`, and the full FFI rotation path against a live server.