### PR TITLE
feat: add snapshotting support to wasm js sdk

### DIFF
--- a/flipt-client-js/README.md
+++ b/flipt-client-js/README.md
@@ -64,6 +64,7 @@ The `FliptClient` constructor accepts the following optional arguments:
   - `updateInterval`: **Node.js Only** The interval (in seconds) in which to fetch new flag state. If not provided, the client will default to 120 seconds.
   - `authentication`: The authentication strategy to use when communicating with the upstream Flipt instance. If not provided, the client will default to no authentication. See the [Authentication](#authentication) section for more information.
   - `reference`: The [reference](https://docs.flipt.io/guides/user/using-references) to use when fetching flag state. If not provided, reference will not be used.
+  - `snapshot`: A base64-encoded snapshot returned by `client.getSnapshot()`. When provided with `errorStrategy: ErrorStrategy.Fallback`, the client can initialize while offline and refresh from Flipt when the network becomes available.
   - `fetcher`: An implementation of a [fetcher](https://github.com/flipt-io/flipt-client-sdks/blob/d0869dc9f6b3a65052712926b88fa0f9b18defaa/flipt-client-js/src/core/types.ts#L60-L62) interface to use when requesting flag state. If not provided, a default fetcher using the browser's [`fetch` API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) will be used.
   - `errorStrategy`: The error strategy to use when fetching flag state. If not provided, the client will default to fail. See the [Error Strategies](#error-strategies) section for more information.
   - `hook`: A hook implementation for before and after evaluation callbacks. See the [Hooks](#hooks) section for more information.
@@ -82,6 +83,29 @@ The client `errorStrategy` option supports the following error strategies:
 
 - `fail`: The client will throw an error if the flag state cannot be fetched. This is the default behavior.
 - `fallback`: The client will maintain the last known good state and use that state for evaluation in case of an error.
+
+### Snapshotting
+
+The client supports manual snapshotting of flag state. This is useful when an app may start before Flipt is reachable. The SDK does not write to local storage for you because browser, Node.js, edge, and worker environments store data differently.
+
+Use `getSnapshot()` to export the current state, store it wherever your app prefers, and pass it back as `snapshot` on the next startup.
+
+```typescript
+import { ErrorStrategy, FliptClient } from '@flipt-io/flipt-client-js';
+
+const snapshot = localStorage.getItem('fliptSnapshot') ?? undefined;
+
+const client = await FliptClient.init({
+  namespace: 'default',
+  url: 'https://your-flipt-instance.com',
+  snapshot,
+  errorStrategy: ErrorStrategy.Fallback
+});
+
+localStorage.setItem('fliptSnapshot', client.getSnapshot());
+```
+
+If Flipt is reachable during initialization, fresh server state replaces the provided snapshot. If Flipt is unreachable and `ErrorStrategy.Fallback` is set, the client evaluates using the provided snapshot.
 
 ### Custom Fetcher
 

--- a/flipt-client-js/src/browser/index.ts
+++ b/flipt-client-js/src/browser/index.ts
@@ -1,6 +1,7 @@
 import init, { Engine } from '../wasm/flipt_engine_wasm_js.js';
 import wasm from '../wasm/flipt_engine_wasm_js_bg.wasm';
 import { BaseFliptClient } from '../core/base';
+import { initializeSnapshot } from '../core/snapshot';
 import { ClientOptions, ClientOptionsFactory } from '../core/types';
 
 export * from '../core/types';
@@ -70,17 +71,15 @@ export class FliptClient extends BaseFliptClient {
       throw new Error('Failed to initialize fetcher');
     }
 
-    // handle case if they pass in a custom fetcher that doesn't throw on non-2xx status codes
-    const resp = await fetcher();
-    if (!resp.ok) {
-      throw new Error(`Failed to fetch data: ${resp.statusText}`);
-    }
-
-    const data = await resp.json();
     const engine = new Engine(namespace);
-    engine.snapshot(data);
     const client = new FliptClient(engine, fetcher);
-    client.storeEtag(resp);
+    await initializeSnapshot({
+      engine,
+      snapshot: options.snapshot,
+      errorStrategy: options.errorStrategy,
+      fetcher,
+      storeEtag: (resp) => client.storeEtag(resp)
+    });
     client.errorStrategy = options.errorStrategy;
     client.hook = options.hook;
     return client;

--- a/flipt-client-js/src/core/base.ts
+++ b/flipt-client-js/src/core/base.ts
@@ -43,6 +43,13 @@ export abstract class BaseFliptClient {
   }
 
   /**
+   * Returns a base64-encoded snapshot of the current flag state.
+   */
+  public getSnapshot(): string {
+    return this.engine.get_snapshot();
+  }
+
+  /**
    * Refresh the flags snapshot
    * @returns true if snapshot changed
    */

--- a/flipt-client-js/src/core/snapshot.test.ts
+++ b/flipt-client-js/src/core/snapshot.test.ts
@@ -1,0 +1,87 @@
+import { initializeSnapshot } from './snapshot';
+import { ErrorStrategy, Response } from './types';
+
+const response = (body: unknown, ok = true): Response => ({
+  ok,
+  status: ok ? 200 : 500,
+  statusText: ok ? 'OK' : 'Server Error',
+  headers: { get: () => 'etag-1' },
+  json: async () => body
+});
+
+test('seeds snapshot before fetching fresh state', async () => {
+  const calls: string[] = [];
+  const engine = {
+    seed_snapshot: (snapshot: string) => calls.push(`seed:${snapshot}`),
+    snapshot: (data: unknown) => calls.push(`fresh:${JSON.stringify(data)}`)
+  };
+
+  await initializeSnapshot({
+    engine,
+    snapshot: 'cached',
+    errorStrategy: ErrorStrategy.Fallback,
+    fetcher: async () => response({ flags: [] }),
+    storeEtag: () => calls.push('etag')
+  });
+
+  expect(calls).toEqual(['seed:cached', 'fresh:{"flags":[]}', 'etag']);
+});
+
+test('allows offline init when snapshot and fallback strategy are provided', async () => {
+  const calls: string[] = [];
+  const engine = {
+    seed_snapshot: (snapshot: string) => calls.push(`seed:${snapshot}`),
+    snapshot: () => calls.push('fresh')
+  };
+
+  await expect(
+    initializeSnapshot({
+      engine,
+      snapshot: 'cached',
+      errorStrategy: ErrorStrategy.Fallback,
+      fetcher: async () => {
+        throw new Error('offline');
+      },
+      storeEtag: () => calls.push('etag')
+    })
+  ).resolves.toBeUndefined();
+
+  expect(calls).toEqual(['seed:cached']);
+});
+
+test('throws offline init error without a snapshot', async () => {
+  const engine = {
+    seed_snapshot: () => undefined,
+    snapshot: () => undefined
+  };
+
+  await expect(
+    initializeSnapshot({
+      engine,
+      errorStrategy: ErrorStrategy.Fallback,
+      fetcher: async () => {
+        throw new Error('offline');
+      },
+      storeEtag: () => undefined
+    })
+  ).rejects.toThrow('offline');
+});
+
+test('throws offline init error with snapshot unless strategy is fallback', async () => {
+  const engine = {
+    seed_snapshot: () => undefined,
+    snapshot: () => undefined
+  };
+
+  await expect(
+    initializeSnapshot({
+      engine,
+      snapshot: 'cached',
+      errorStrategy: ErrorStrategy.Fail,
+      fetcher: async () => {
+        throw new Error('offline');
+      },
+      storeEtag: () => undefined
+    })
+  ).rejects.toThrow('offline');
+});

--- a/flipt-client-js/src/core/snapshot.ts
+++ b/flipt-client-js/src/core/snapshot.ts
@@ -1,0 +1,39 @@
+import { ErrorStrategy, Response } from './types';
+
+type SnapshotEngine = {
+  seed_snapshot(snapshot: string): void;
+  snapshot(data: unknown): void;
+};
+
+export async function initializeSnapshot({
+  engine,
+  snapshot,
+  errorStrategy,
+  fetcher,
+  storeEtag
+}: {
+  engine: SnapshotEngine;
+  snapshot?: string;
+  errorStrategy?: ErrorStrategy;
+  fetcher: () => Promise<Response>;
+  storeEtag: (resp: Response) => void;
+}): Promise<void> {
+  if (snapshot) {
+    engine.seed_snapshot(snapshot);
+  }
+
+  try {
+    const resp = await fetcher();
+    if (!resp.ok) {
+      throw new Error(`Failed to fetch data: ${resp.statusText}`);
+    }
+
+    const data = await resp.json();
+    engine.snapshot(data);
+    storeEtag(resp);
+  } catch (error) {
+    if (!snapshot || errorStrategy !== ErrorStrategy.Fallback) {
+      throw error;
+    }
+  }
+}

--- a/flipt-client-js/src/core/types.ts
+++ b/flipt-client-js/src/core/types.ts
@@ -126,6 +126,13 @@ export interface ClientOptions {
   reference?: string;
 
   /**
+   * Base64-encoded snapshot returned by getSnapshot(). When provided with
+   * ErrorStrategy.Fallback, the client can initialize offline and refresh when
+   * Flipt becomes reachable again.
+   */
+  snapshot?: string;
+
+  /**
    * The fetcher to use when fetching flag state. If not provided, the client will default to a fetch function.
    */
   fetcher?: IFetcher;

--- a/flipt-client-js/src/node/index.ts
+++ b/flipt-client-js/src/node/index.ts
@@ -1,6 +1,7 @@
 import init, { Engine } from '../wasm/flipt_engine_wasm_js.js';
 import wasm from '../wasm/flipt_engine_wasm_js_bg.wasm';
 import { BaseFliptClient } from '../core/base';
+import { initializeSnapshot } from '../core/snapshot';
 import { ClientOptions, ClientOptionsFactory } from '../core/types';
 
 export * from '../core/types';
@@ -76,19 +77,17 @@ export class FliptClient extends BaseFliptClient {
       throw new Error('Failed to initialize fetcher');
     }
 
-    // handle case if they pass in a custom fetcher that doesn't throw on non-2xx status codes
-    const resp = await fetcher();
-    if (!resp.ok) {
-      throw new Error(`Failed to fetch data: ${resp.statusText}`);
-    }
-
-    const data = await resp.json();
     const engine = new Engine(namespace);
-    engine.snapshot(data);
 
     // We know fetcher is defined here since we checked above
     const client = new FliptClient(engine, fetcher);
-    client.storeEtag(resp);
+    await initializeSnapshot({
+      engine,
+      snapshot: options.snapshot,
+      errorStrategy: options.errorStrategy,
+      fetcher,
+      storeEtag: (resp) => client.storeEtag(resp)
+    });
     client.errorStrategy = options.errorStrategy;
     client.hook = options.hook;
 

--- a/flipt-client-js/src/slim/index.ts
+++ b/flipt-client-js/src/slim/index.ts
@@ -1,5 +1,6 @@
 import init, { Engine } from '../wasm/flipt_engine_wasm_js.js';
 import { BaseFliptClient } from '../core/base';
+import { initializeSnapshot } from '../core/snapshot';
 import { ClientOptions, ClientOptionsFactory } from '../core/types';
 
 export * from '../core/types';
@@ -95,19 +96,17 @@ export class FliptClient extends BaseFliptClient {
       throw new Error('Failed to initialize fetcher');
     }
 
-    // handle case if they pass in a custom fetcher that doesn't throw on non-2xx status codes
-    const resp = await fetcher();
-    if (!resp.ok) {
-      throw new Error(`Failed to fetch data: ${resp.statusText}`);
-    }
-
-    const data = await resp.json();
     const engine = new Engine(namespace);
-    engine.snapshot(data);
 
     // Create client instance
     const client = new FliptClient(engine, fetcher);
-    client.storeEtag(resp);
+    await initializeSnapshot({
+      engine,
+      snapshot: options.snapshot,
+      errorStrategy: options.errorStrategy,
+      fetcher,
+      storeEtag: (resp) => client.storeEtag(resp)
+    });
     client.errorStrategy = options.errorStrategy;
     client.hook = options.hook;
 

--- a/flipt-client-react/README.md
+++ b/flipt-client-react/README.md
@@ -149,6 +149,8 @@ The `FliptProvider` component accepts two optional arguments:
   - `authentication`: The authentication strategy to use when communicating with the upstream Flipt instance. If not provided, the client will default to no authentication. See the [Authentication](#authentication) section for more information.
   - `updateInterval`: The polling interval (in seconds) for fetching new state from Flipt. Set to `120` seconds by default. A `0` value disables polling completely after the initial fetch.
   - `reference`: The [reference](https://docs.flipt.io/guides/user/using-references) to use when fetching flag state. If not provided, reference will not be used.
+  - `snapshot`: A base64-encoded snapshot returned by the underlying JS client's `getSnapshot()` method. Use this with `errorStrategy: ErrorStrategy.Fallback` to allow startup while Flipt is unreachable.
+  - `errorStrategy`: The strategy for fetch errors. Use `ErrorStrategy.Fallback` with `snapshot` for offline startup.
   - `fetcher`: An implementation of a [fetcher](https://github.com/flipt-io/flipt-client-sdks/blob/4821cb227c6c8b10419b96674d44ad1d6668a647/flipt-client-browser/src/models.ts#L5) interface to use when requesting flag state. If not provided, a default fetcher using the browser's [`fetch` API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) will be used.
 
 ### Authentication
@@ -158,6 +160,46 @@ The `FliptProvider` component supports the following authentication strategies:
 - No Authentication (default)
 - [Client Token Authentication](https://docs.flipt.io/authentication/using-tokens)
 - [JWT Authentication](https://docs.flipt.io/authentication/using-jwts)
+
+### Offline Startup with Snapshots
+
+`flipt-client-react` uses `@flipt-io/flipt-client-js` under the hood, so it supports the same manual snapshot flow. Store the snapshot yourself, then pass it through `FliptProvider` options on the next page load.
+
+```tsx
+import { ErrorStrategy } from '@flipt-io/flipt-client-js';
+import { FliptProvider, useFliptSelector } from '@flipt-io/flipt-client-react';
+
+function PersistFliptSnapshot() {
+  useFliptSelector((client) => {
+    if (client) {
+      localStorage.setItem('fliptSnapshot', client.getSnapshot());
+    }
+    return null;
+  });
+
+  return null;
+}
+
+function App() {
+  const snapshot = localStorage.getItem('fliptSnapshot') ?? undefined;
+
+  return (
+    <FliptProvider
+      options={{
+        namespace: 'default',
+        url: 'https://your-flipt-instance.com',
+        snapshot,
+        errorStrategy: ErrorStrategy.Fallback
+      }}
+    >
+      <PersistFliptSnapshot />
+      {/* Your app components */}
+    </FliptProvider>
+  );
+}
+```
+
+The provider will use the cached snapshot if startup fetch fails. When Flipt is reachable, fresh state replaces the cached snapshot and `getSnapshot()` returns the latest state.
 
 ## Examples
 

--- a/flipt-engine-wasm-js/Cargo.toml
+++ b/flipt-engine-wasm-js/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { version = "1.0.89", features = ["raw_value"] }
 serde-wasm-bindgen = "0.6.5"
 console_error_panic_hook = "0.1.7"
 chrono = { version = "0.4.31", features = ["wasmbind"] }
+base64 = "0.22"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/flipt-engine-wasm-js/src/lib.rs
+++ b/flipt-engine-wasm-js/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate console_error_panic_hook;
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine as Base64Engine;
 use wasm_bindgen::prelude::*;
 
 use fliptevaluation::{
@@ -76,6 +78,25 @@ impl Engine {
 
         self.store = snapshot::Snapshot::build(doc);
         Ok(())
+    }
+
+    pub fn seed_snapshot(&mut self, snapshot_b64: &str) -> Result<(), JsValue> {
+        let decoded = BASE64_STANDARD
+            .decode(snapshot_b64)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        let snapshot: snapshot::Snapshot =
+            serde_json::from_slice(&decoded).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        self.store = snapshot;
+        Ok(())
+    }
+
+    pub fn get_snapshot(&self) -> Result<String, JsValue> {
+        let json =
+            serde_json::to_string(&self.store).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        Ok(BASE64_STANDARD.encode(json))
     }
 
     pub fn evaluate_boolean(&self, request: JsValue) -> Result<JsValue, JsValue> {
@@ -182,6 +203,49 @@ pub mod tests {
 
         let result = engine.evaluate_batch(req);
         assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_get_and_seed_snapshot_round_trip() {
+        let mut engine = Engine::new("default");
+        let state = r#"
+        {
+         "namespace": { "key": "default"},
+         "flags": [
+             {
+             "key": "flag1",
+             "name": "flag1",
+             "description": "foo flag",
+             "enabled": true,
+             "type": "BOOLEAN_FLAG_TYPE",
+             "createdAt": "2024-09-13T19:37:18.723909Z",
+             "updatedAt": "2024-09-13T19:37:18.723909Z",
+             "rules": [],
+             "rollouts": []
+        }]}"#;
+
+        let document: source::Document = serde_json::from_str(state).expect("valid snapshot");
+        let data = serde_wasm_bindgen::to_value(&document).unwrap();
+        engine.snapshot(data).unwrap();
+
+        let encoded = engine.get_snapshot().expect("snapshot export");
+        assert!(!encoded.is_empty());
+
+        let mut seeded = Engine::new("default");
+        seeded.seed_snapshot(&encoded).expect("snapshot seed");
+
+        let flags = seeded.list_flags().expect("flags response");
+        let response: JsResponse<Vec<fliptevaluation::models::flipt::Flag>> =
+            serde_wasm_bindgen::from_value(flags).expect("list flags response");
+        assert_eq!(response.status, Status::Success);
+        assert_eq!(response.result.unwrap().len(), 1);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_seed_snapshot_rejects_invalid_base64() {
+        let mut engine = Engine::new("default");
+        let result = engine.seed_snapshot("not base64");
+        assert!(result.is_err());
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- add base64 snapshot export/import methods to `flipt-engine-wasm-js`
- add `snapshot` option and `getSnapshot()` to `flipt-client-js`
- allow JS/browser/node/slim clients to initialize from a cached snapshot with `ErrorStrategy.Fallback`
- document JS and React offline startup patterns

## Test Plan
- [x] `cd flipt-engine-wasm-js && wasm-pack test --node`
- [x] `cd flipt-client-js && npm test -- src/core/snapshot.test.ts`
- [x] `cd flipt-client-js && npm run lint && npm run build`
- [x] `cd flipt-client-react && npm run lint && npm run build`

Closes #1480