### PR TITLE
ci: skip draft PR reviews

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,7 +16,7 @@ name: PR Review
 on:
   pull_request_target:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   review:
     # Skip Dependabot (it runs in a restricted context and we don't review it).
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary
- Skip automated agent reviews for draft PRs.
- Run the workflow when a draft PR is marked ready for review.

## Test Plan
- [x] `git diff --check`
- [x] Parsed `.github/workflows/pr-review.yml` with Ruby YAML loader
- [x] Grep-checked `ready_for_review` trigger and `draft == false` guard