### PR TITLE
chore: release flipt-engine-wasm-js v0.4.0

### DIFF
--- a/flipt-engine-wasm-js/Cargo.toml
+++ b/flipt-engine-wasm-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-engine-wasm-js"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"


### PR DESCRIPTION
Bumps flipt-engine-wasm-js to v0.4.0 for the snapshotting feature merged in #1796.\n\nVerification:\n- cargo check -p flipt-engine-wasm-js