### PR TITLE
feat: add Go WASM snapshot support

### DIFF
--- a/flipt-client-go/README.md
+++ b/flipt-client-go/README.md
@@ -123,6 +123,7 @@ The `NewClient` constructor accepts a variadic number of `Option` functions that
 - `WithUpdateInterval`: The interval in which to fetch new flag state. If not provided, the client will default to 120 seconds.
 - `With{Method}Authentication`: The authentication strategy to use when communicating with the upstream Flipt instance. If not provided, the client will default to no authentication. See the [Authentication](#authentication) section for more information.
 - `WithReference`: The [reference](https://docs.flipt.io/guides/user/using-references) to use when fetching flag state. If not provided, reference will not be used.
+- `WithSnapshot`: A base64-encoded snapshot returned by `Client.GetSnapshot`. When used with `ErrorStrategyFallback`, the client can initialize from this snapshot if Flipt is unreachable during startup.
 - `WithFetchMode`: The fetch mode to use when fetching flag state. If not provided, the client will default to polling.
 - `WithErrorStrategy`: The error strategy to use when fetching flag state. If not provided, the client will default to `Fail`. See the [Error Strategies](#error-strategies) section for more information.
 - `WithTLSConfig`: The TLS configuration for connecting to servers with custom certificates. See [TLS Configuration](#tls-configuration). Note: if used with `WithHTTPClient`, this should be called after setting the HTTP client.
@@ -262,6 +263,24 @@ tlsConfig := &tls.Config{
   // Server name for SNI
   ServerName: "flipt.example.com",
 }
+```
+
+### Snapshots
+
+Use `GetSnapshot` to persist the current flag state and pass it back with `WithSnapshot` on the next startup. This is useful for offline startup when paired with `ErrorStrategyFallback`.
+
+```go
+snapshot, err := client.GetSnapshot(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+
+client, err = flipt.NewClient(
+    ctx,
+    flipt.WithURL("http://localhost:8080"),
+    flipt.WithSnapshot(snapshot),
+    flipt.WithErrorStrategy(flipt.ErrorStrategyFallback),
+)
 ```
 
 ### Error Strategies

--- a/flipt-client-go/client.go
+++ b/flipt-client-go/client.go
@@ -38,6 +38,8 @@ const (
 	fAllocate         = "allocate"
 	fDeallocate       = "deallocate"
 	fSnapshot         = "snapshot"
+	fSeedSnapshot     = "seed_snapshot"
+	fGetSnapshot      = "get_snapshot"
 	fEvaluateVariant  = "evaluate_variant"
 	fEvaluateBoolean  = "evaluate_boolean"
 	fEvaluateBatch    = "evaluate_batch"
@@ -137,8 +139,11 @@ func NewClient(ctx context.Context, opts ...Option) (_ *Client, err error) {
 	c.exportedFuncs = map[string]api.Function{
 		fAllocate:        allocFunc,
 		fDeallocate:      deallocFunc,
+		fSnapshot:        mod.ExportedFunction(fSnapshot),
 		fEvaluateVariant: mod.ExportedFunction(fEvaluateVariant),
 		fEvaluateBoolean: mod.ExportedFunction(fEvaluateBoolean),
+		fSeedSnapshot:    mod.ExportedFunction(fSeedSnapshot),
+		fGetSnapshot:     mod.ExportedFunction(fGetSnapshot),
 		fEvaluateBatch:   mod.ExportedFunction(fEvaluateBatch),
 		fListFlags:       mod.ExportedFunction(fListFlags),
 	}
@@ -160,42 +165,51 @@ func NewClient(ctx context.Context, opts ...Option) (_ *Client, err error) {
 	}
 
 	// fetch initial state
-	snapshot, err := c.fetch(ctx, initialURL, "")
+	state, err := c.fetch(ctx, initialURL, "")
+	fetchErr := err
 	if err != nil {
 		if cfg.ErrorStrategy == ErrorStrategyFallback {
 			c.mu.Lock()
 			c.err = err
 			c.mu.Unlock()
-			snapshot = c.emptyPayload(c.cfg.Namespace)
+			state = c.emptyPayload(c.cfg.Namespace)
 		} else {
 			return nil, fmt.Errorf("failed to fetch initial state: %w", err)
 		}
 	}
 
 	// set initial etag
-	c.etag = snapshot.etag
+	c.etag = state.etag
 
 	// allocate payload
-	pmPtr, err := allocFunc.Call(ctx, uint64(len(snapshot.payload)))
+	pmPtr, err := allocFunc.Call(ctx, uint64(len(state.payload)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate memory for payload: %w", err)
 	}
-
-	if !mod.Memory().Write(uint32(pmPtr[0]), snapshot.payload) {
+	if !mod.Memory().Write(uint32(pmPtr[0]), state.payload) {
 		return nil, fmt.Errorf("failed to write payload to memory")
 	}
 
 	// initialize engine
-	res, err := initializeEngine.Call(ctx, nsPtr[0], uint64(len(c.cfg.Namespace)), pmPtr[0], uint64(len(snapshot.payload)))
+	res, err := initializeEngine.Call(ctx, nsPtr[0], uint64(len(c.cfg.Namespace)), pmPtr[0], uint64(len(state.payload)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize engine: %w", err)
 	}
-
 	if len(res) < 1 || res[0] == 0 {
 		return nil, fmt.Errorf("failed to initialize engine: invalid pointer returned")
 	}
-
 	c.engine = uint32(res[0])
+
+	if cfg.Snapshot != "" {
+		if err := c.seedSnapshot(ctx, cfg.Snapshot); err != nil {
+			return nil, fmt.Errorf("failed initialize engine from snapshot: %w", err)
+		}
+		if fetchErr == nil {
+			if err := c.updateSnapshot(ctx, state.payload); err != nil {
+				return nil, fmt.Errorf("failed initialize engine with fetched state: %w", err)
+			}
+		}
+	}
 
 	c.wg.Add(1)
 	go func() {
@@ -253,6 +267,104 @@ func (c *Client) Err() error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.err
+}
+
+// GetSnapshot returns a base64-encoded snapshot of the current flag state.
+func (c *Client) GetSnapshot(ctx context.Context) (string, error) {
+	getSnapshotFunc, ok := c.exportedFuncs[fGetSnapshot]
+	if !ok {
+		return "", errors.New("failed find get_snapshot function")
+	}
+	deallocFunc := c.exportedFuncs[fDeallocate]
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	res, err := getSnapshotFunc.Call(ctx, uint64(c.engine))
+	if err != nil {
+		return "", fmt.Errorf("failed call get_snapshot: %w", err)
+	}
+	if len(res) < 1 {
+		return "", fmt.Errorf("failed call get_snapshot: no result returned")
+	}
+
+	ptr, length := decodePtr(res[0])
+	b, ok := c.mod.Memory().Read(ptr, length)
+	if !ok {
+		_, _ = deallocFunc.Call(ctx, uint64(ptr), uint64(length))
+		return "", fmt.Errorf("failed read result from memory")
+	}
+
+	result := make([]byte, len(b))
+	copy(result, b)
+	if _, err := deallocFunc.Call(ctx, uint64(ptr), uint64(length)); err != nil {
+		return "", fmt.Errorf("failed deallocate memory: %w", err)
+	}
+
+	snapshot, err := decodeResult[string](result)
+	if err != nil {
+		return "", err
+	}
+	return *snapshot, nil
+}
+
+func (c *Client) seedSnapshot(ctx context.Context, snapshot string) error {
+	seedSnapshotFunc, ok := c.exportedFuncs[fSeedSnapshot]
+	if !ok {
+		return errors.New("failed find seed_snapshot function")
+	}
+	return c.callWASMWithPayload(ctx, seedSnapshotFunc, []byte(snapshot))
+}
+
+func (c *Client) updateSnapshot(ctx context.Context, payload []byte) error {
+	snapshotFunc, ok := c.exportedFuncs[fSnapshot]
+	if !ok {
+		return errors.New("failed find snapshot function")
+	}
+	return c.callWASMWithPayload(ctx, snapshotFunc, payload)
+}
+
+func (c *Client) callWASMWithPayload(ctx context.Context, fn api.Function, payload []byte) error {
+	allocFunc := c.exportedFuncs[fAllocate]
+	deallocFunc := c.exportedFuncs[fDeallocate]
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	payloadPtr, err := allocFunc.Call(ctx, uint64(len(payload)))
+	if err != nil {
+		return fmt.Errorf("failed allocate memory payload: %w", err)
+	}
+	if !c.mod.Memory().Write(uint32(payloadPtr[0]), payload) {
+		_, _ = deallocFunc.Call(ctx, payloadPtr[0], uint64(len(payload)))
+		return fmt.Errorf("failed write payload memory")
+	}
+
+	res, err := fn.Call(ctx, uint64(c.engine), payloadPtr[0], uint64(len(payload)))
+	if _, deallocErr := deallocFunc.Call(ctx, payloadPtr[0], uint64(len(payload))); deallocErr != nil {
+		return fmt.Errorf("failed deallocate memory: %w", deallocErr)
+	}
+	if err != nil {
+		return fmt.Errorf("failed call wasm function: %w", err)
+	}
+	if len(res) < 1 {
+		return fmt.Errorf("failed call wasm function: no result returned")
+	}
+
+	ptr, length := decodePtr(res[0])
+	b, ok := c.mod.Memory().Read(ptr, length)
+	if !ok {
+		_, _ = deallocFunc.Call(ctx, uint64(ptr), uint64(length))
+		return fmt.Errorf("failed read result from memory")
+	}
+
+	result := make([]byte, len(b))
+	copy(result, b)
+	if _, err := deallocFunc.Call(ctx, uint64(ptr), uint64(length)); err != nil {
+		return fmt.Errorf("failed deallocate memory: %w", err)
+	}
+
+	return decodeStatus(result)
 }
 
 // EvaluateVariant performs evaluation for a variant flag.
@@ -471,6 +583,20 @@ func decodeResult[R any](payload []byte) (*R, error) {
 	}
 
 	return decoded.Result, nil
+}
+
+func decodeStatus(payload []byte) error {
+	var decoded *Result[json.RawMessage]
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return fmt.Errorf("failed to unmarshal result: %w", err)
+	}
+	if decoded == nil {
+		return fmt.Errorf("failed to unmarshal result: nil")
+	}
+	if decoded.Status != statusSuccess {
+		return errors.New(decoded.ErrorMessage)
+	}
+	return nil
 }
 
 type snapshot struct {

--- a/flipt-client-go/client_test.go
+++ b/flipt-client-go/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"os"
 	"strings"
 	"testing"
@@ -342,6 +343,20 @@ func TestWithSnapshotInvalid(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, client)
 	assert.Contains(t, err.Error(), "failed initialize engine")
+}
+
+func TestWithSnapshotNamespaceMismatch(t *testing.T) {
+	ctx := context.Background()
+	snapshot := base64.StdEncoding.EncodeToString([]byte(`{"version":1,"namespace":{"key":"other","flags":{},"eval_rules":{},"eval_rollouts":{},"eval_distributions":{}}}`))
+	client, err := flipt.NewClient(ctx,
+		flipt.WithURL("http://localhost:19999"),
+		flipt.WithNamespace("test"),
+		flipt.WithSnapshot(snapshot),
+		flipt.WithErrorStrategy(flipt.ErrorStrategyFallback),
+	)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "snapshot namespace 'other' does not match engine namespace 'test'")
 }
 
 func TestErrorStrategyFallback_EvaluationReturnsError(t *testing.T) {

--- a/flipt-client-go/client_test.go
+++ b/flipt-client-go/client_test.go
@@ -304,6 +304,46 @@ func TestErrorStrategyDefault_InitializationWithInvalidURL(t *testing.T) {
 	assert.Nil(t, client, "client should be nil when initialization fails")
 }
 
+func (s *ClientTestSuite) TestSnapshotRoundTripOfflineFallback() {
+	ctx := context.Background()
+
+	snapshot, err := s.client.GetSnapshot(ctx)
+	s.Require().NoError(err)
+	s.NotEmpty(snapshot)
+
+	client, err := flipt.NewClient(ctx,
+		flipt.WithURL("http://localhost:19999"),
+		flipt.WithSnapshot(snapshot),
+		flipt.WithErrorStrategy(flipt.ErrorStrategyFallback),
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(client)
+	s.T().Cleanup(func() {
+		s.Require().NoError(client.Close(ctx))
+	})
+
+	variant, err := client.EvaluateVariant(ctx, &flipt.EvaluationRequest{FlagKey: "flag1", EntityID: "someentity", Context: map[string]string{
+		"fizz": "buzz",
+	}})
+	s.Require().NoError(err)
+	s.True(variant.Match)
+	s.Equal("flag1", variant.FlagKey)
+	s.Equal("MATCH_EVALUATION_REASON", variant.Reason)
+	s.Equal("variant1", variant.VariantKey)
+}
+
+func TestWithSnapshotInvalid(t *testing.T) {
+	ctx := context.Background()
+	client, err := flipt.NewClient(ctx,
+		flipt.WithURL("http://localhost:19999"),
+		flipt.WithSnapshot("not base64"),
+		flipt.WithErrorStrategy(flipt.ErrorStrategyFallback),
+	)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "failed initialize engine")
+}
+
 func TestErrorStrategyFallback_EvaluationReturnsError(t *testing.T) {
 	ctx := context.Background()
 

--- a/flipt-client-go/config.go
+++ b/flipt-client-go/config.go
@@ -56,6 +56,15 @@ func WithReference(ref string) Option {
 	}
 }
 
+// WithSnapshot sets a base64-encoded snapshot returned by Client.GetSnapshot.
+// When provided with ErrorStrategyFallback, the client can initialize from the
+// snapshot if the initial fetch fails.
+func WithSnapshot(snapshot string) Option {
+	return func(cfg *config) {
+		cfg.Snapshot = snapshot
+	}
+}
+
 // WithUpdateInterval sets the update interval for the client.
 func WithUpdateInterval(updateInterval time.Duration) Option {
 	return func(cfg *config) {
@@ -183,6 +192,8 @@ type config struct {
 	Authentication any
 	// Reference to use when fetching flag state. Optional.
 	Reference string
+	// Snapshot is base64-encoded flag state returned by Client.GetSnapshot. Optional.
+	Snapshot string
 	// FetchMode determines how flag state is fetched (polling or streaming). Defaults to polling.
 	FetchMode FetchMode
 	// ErrorStrategy determines how errors are handled (fail or fallback). Defaults to fail.

--- a/flipt-client-js/integration/snapshot.mjs
+++ b/flipt-client-js/integration/snapshot.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { ErrorStrategy, FliptClient } from '../dist/node/index.mjs';
+
+const url = process.env.FLIPT_URL;
+if (!url) {
+  console.log('skipping snapshot integration: FLIPT_URL not set');
+  process.exit(0);
+}
+
+const authToken = process.env.FLIPT_AUTH_TOKEN;
+const options = {
+  url,
+  authentication: authToken ? { clientToken: authToken } : undefined
+};
+
+const online = await FliptClient.init(options);
+try {
+  const snapshot = online.getSnapshot();
+  assert.ok(snapshot, 'expected exported snapshot');
+
+  const offline = await FliptClient.init({
+    snapshot,
+    errorStrategy: ErrorStrategy.Fallback,
+    fetcher: async () => {
+      throw new Error('offline');
+    }
+  });
+
+  try {
+    const variant = offline.evaluateVariant({
+      flagKey: 'flag1',
+      entityId: 'someentity',
+      context: { fizz: 'buzz' }
+    });
+
+    assert.equal(variant.match, true);
+    assert.equal(variant.flagKey, 'flag1');
+    assert.equal(variant.reason, 'MATCH_EVALUATION_REASON');
+    assert.equal(variant.variantKey, 'variant1');
+  } finally {
+    offline.close();
+  }
+} finally {
+  online.close();
+}

--- a/flipt-client-js/package-lock.json
+++ b/flipt-client-js/package-lock.json
@@ -78,7 +78,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -532,13 +531,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2016,7 +2039,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -2544,6 +2566,40 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
@@ -2592,7 +2648,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2831,7 +2886,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3265,7 +3319,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4393,7 +4446,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -5854,7 +5906,6 @@
       "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -6208,7 +6259,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6318,8 +6368,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6362,7 +6411,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/flipt-engine-wasm-js/src/lib.rs
+++ b/flipt-engine-wasm-js/src/lib.rs
@@ -88,6 +88,13 @@ impl Engine {
         let snapshot: snapshot::Snapshot =
             serde_json::from_slice(&decoded).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
+        if snapshot.namespace.key != self.namespace {
+            return Err(JsValue::from_str(&format!(
+                "snapshot namespace '{}' does not match engine namespace '{}'",
+                snapshot.namespace.key, self.namespace
+            )));
+        }
+
         self.store = snapshot;
         Ok(())
     }
@@ -246,6 +253,21 @@ pub mod tests {
         let mut engine = Engine::new("default");
         let result = engine.seed_snapshot("not base64");
         assert!(result.is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_seed_snapshot_rejects_namespace_mismatch() {
+        let snapshot = snapshot::Snapshot::empty("other");
+        let encoded = BASE64_STANDARD.encode(serde_json::to_string(&snapshot).expect("snapshot"));
+        let mut engine = Engine::new("default");
+
+        let result = engine.seed_snapshot(&encoded);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().and_then(|e| e.as_string()).unwrap(),
+            "snapshot namespace 'other' does not match engine namespace 'default'"
+        );
     }
 
     #[wasm_bindgen_test]

--- a/flipt-engine-wasm/Cargo.toml
+++ b/flipt-engine-wasm/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/flipt-io/flipt-client-sdks"
 crate-type = ["cdylib"]
 
 [dependencies]
+base64 = "0.22"
 libc = { version = "0.2.150", features = ["std"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["raw_value"] }

--- a/flipt-engine-wasm/src/lib.rs
+++ b/flipt-engine-wasm/src/lib.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine as _;
 use fliptevaluation::error::Error;
 use fliptevaluation::models::flipt::Flag;
 use fliptevaluation::models::{snapshot, source};
@@ -47,6 +49,8 @@ pub enum WASMError {
     NullPointer,
     #[error("Internal error: {0}")]
     InternalError(String),
+    #[error("Invalid snapshot: {0}")]
+    InvalidSnapshot(String),
 }
 
 impl<T, E> From<Result<T, E>> for WASMResponse<T>
@@ -101,6 +105,21 @@ impl Engine {
         let doc: source::Document = serde_json::from_str(data).map_err(WASMError::InvalidJson)?;
         self.store = snapshot::Snapshot::build(doc);
         Ok(())
+    }
+
+    pub fn seed_snapshot(&mut self, snapshot_b64: &str) -> Result<(), WASMError> {
+        let decoded = BASE64_STANDARD
+            .decode(snapshot_b64)
+            .map_err(|e| WASMError::InvalidSnapshot(e.to_string()))?;
+        let snapshot: snapshot::Snapshot =
+            serde_json::from_slice(&decoded).map_err(WASMError::InvalidJson)?;
+        self.store = snapshot;
+        Ok(())
+    }
+
+    pub fn get_snapshot(&self) -> Result<String, WASMError> {
+        let json = serde_json::to_string(&self.store).map_err(WASMError::InvalidJson)?;
+        Ok(BASE64_STANDARD.encode(json))
     }
 
     pub fn evaluate_boolean(
@@ -399,6 +418,66 @@ pub unsafe extern "C" fn snapshot(
     result.unwrap_or_else(|_| unsafe {
         result_to_ptr::<(), _>(Err(WASMError::InternalError(
             "panic in snapshot".to_string(),
+        )))
+    })
+}
+
+/// # Safety
+///
+/// Seed the engine from a base64-encoded serialized snapshot.
+#[no_mangle]
+pub unsafe extern "C" fn seed_snapshot(
+    engine_ptr: *mut c_void,
+    snapshot_ptr: *const u8,
+    snapshot_len: usize,
+) -> u64 {
+    let result = std::panic::catch_unwind(|| {
+        let e = match get_engine(engine_ptr) {
+            Ok(e) => e,
+            Err(e) => return result_to_ptr::<(), _>(Err(e)),
+        };
+
+        if snapshot_ptr.is_null() || snapshot_len == 0 {
+            return result_to_ptr::<(), _>(Err(WASMError::NullPointer));
+        }
+
+        let snapshot =
+            match std::str::from_utf8(std::slice::from_raw_parts(snapshot_ptr, snapshot_len)) {
+                Ok(s) => s,
+                Err(_) => {
+                    return result_to_ptr::<(), _>(Err(WASMError::InvalidSnapshot(
+                        "Invalid UTF-8 in snapshot".to_string(),
+                    )))
+                }
+            };
+
+        result_to_ptr(e.seed_snapshot(snapshot))
+    });
+
+    result.unwrap_or_else(|_| unsafe {
+        result_to_ptr::<(), _>(Err(WASMError::InternalError(
+            "panic in seed_snapshot".to_string(),
+        )))
+    })
+}
+
+/// # Safety
+///
+/// Return a base64-encoded serialized snapshot.
+#[no_mangle]
+pub unsafe extern "C" fn get_snapshot(engine_ptr: *mut c_void) -> u64 {
+    let result = std::panic::catch_unwind(|| {
+        let e = match get_engine(engine_ptr) {
+            Ok(e) => e,
+            Err(e) => return result_to_ptr::<String, _>(Err(e)),
+        };
+
+        result_to_ptr(e.get_snapshot())
+    });
+
+    result.unwrap_or_else(|_| unsafe {
+        result_to_ptr::<String, _>(Err(WASMError::InternalError(
+            "panic in get_snapshot".to_string(),
         )))
     })
 }

--- a/flipt-engine-wasm/src/lib.rs
+++ b/flipt-engine-wasm/src/lib.rs
@@ -113,6 +113,12 @@ impl Engine {
             .map_err(|e| WASMError::InvalidSnapshot(e.to_string()))?;
         let snapshot: snapshot::Snapshot =
             serde_json::from_slice(&decoded).map_err(WASMError::InvalidJson)?;
+        if snapshot.namespace.key != self.namespace {
+            return Err(WASMError::InvalidSnapshot(format!(
+                "snapshot namespace '{}' does not match engine namespace '{}'",
+                snapshot.namespace.key, self.namespace
+            )));
+        }
         self.store = snapshot;
         Ok(())
     }
@@ -599,4 +605,28 @@ unsafe fn result_to_ptr<T: Serialize, E: std::error::Error>(result: Result<T, E>
     let (ptr, len) = string_to_ptr(&result);
     std::mem::forget(result);
     ((ptr as u64) << 32) | len as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded_snapshot(namespace: &str) -> String {
+        let snapshot = snapshot::Snapshot::empty(namespace);
+        BASE64_STANDARD.encode(serde_json::to_string(&snapshot).expect("serialize snapshot"))
+    }
+
+    #[test]
+    fn seed_snapshot_rejects_namespace_mismatch() {
+        let mut engine = Engine::new("default", r#"{"namespace":{"key":"default"},"flags":[]}"#)
+            .expect("engine");
+
+        let err = engine
+            .seed_snapshot(&encoded_snapshot("other"))
+            .expect_err("namespace mismatch should fail");
+
+        assert!(err
+            .to_string()
+            .contains("snapshot namespace 'other' does not match engine namespace 'default'"));
+    }
 }

--- a/test/main.go
+++ b/test/main.go
@@ -538,6 +538,7 @@ func javascriptTests(ctx context.Context, root *dagger.Container, t *testCase) e
 		WithExec(args("npm install")).
 		WithExec(args("npm run build")).
 		WithExec(args("npm test")).
+		WithExec(args("node integration/snapshot.mjs")).
 		Sync(ctx)
 
 	return err


### PR DESCRIPTION
## Summary
- add snapshot export/seed exports to the Go WASM engine
- expose Go SDK snapshot APIs via `Client.GetSnapshot` and `WithSnapshot`
- add Go snapshot tests plus JS WASM snapshot integration coverage in the Dagger JS flow

## Verification
- `cargo check -p flipt-engine-wasm`
- `cd flipt-client-go && GOWORK=off go test ./... -run 'TestUnauthorized|TestWithSnapshotInvalid|TestErrorStrategyFallback_EvaluationReturnsError'`
- `cd flipt-client-js && npm run build >/tmp/flipt-js-build-final.log 2>&1 && node integration/snapshot.mjs` (local script skipped because `FLIPT_URL` is unset; Dagger provides it)

Related to #1480.