### PR TITLE
fix: return shared &Engine from get_engine to fix aliasing UB

### DIFF
--- a/flipt-engine-ffi/src/lib.rs
+++ b/flipt-engine-ffi/src/lib.rs
@@ -951,11 +951,11 @@ unsafe extern "C" fn _destroy_string(ptr: *mut c_char) {
 
 /// This function should not be called unless an Engine is initiated. It provides a helper
 /// utility to retrieve an Engine instance for evaluation use.
-unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut Engine, FFIError> {
+unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a Engine, FFIError> {
     if engine_ptr.is_null() {
         Err(FFIError::NullPointer)
     } else {
-        Ok(&mut *(engine_ptr as *mut Engine))
+        Ok(&*(engine_ptr as *const Engine))
     }
 }
 
@@ -1268,6 +1268,87 @@ mod tests {
             );
 
             _destroy_string(result_ptr as *mut c_char);
+            _destroy_engine(engine_ptr);
+        }
+    }
+
+    #[test]
+    fn test_concurrent_evaluation_shared_engine() {
+        const THREADS: usize = 8;
+        const ITERATIONS: usize = 500;
+
+        let snapshot = r#"
+{
+    "version": 1,
+    "namespace": {
+        "key": "default",
+        "flags": {
+            "flag1": {
+                "key": "flag1",
+                "enabled": true,
+                "type": "VARIANT_FLAG_TYPE",
+                "description": "flag description"
+            },
+            "flag_boolean": {
+                "key": "flag_boolean",
+                "enabled": true,
+                "type": "BOOLEAN_FLAG_TYPE",
+                "description": "flag description"
+            }
+        },
+        "eval_rules": { "flag1": [], "flag_boolean": [] },
+        "eval_rollouts": { "flag1": [], "flag_boolean": [] },
+        "eval_distributions": {}
+    }
+}
+"#;
+        let encoded_snapshot = BASE64_STANDARD.encode(snapshot);
+        let opts = CString::new(format!(
+            r#"{{"url":"http://localhost:1","error_strategy":"fallback","update_interval":9999,"snapshot":"{encoded_snapshot}"}}"#
+        ))
+        .unwrap();
+
+        unsafe {
+            let engine_ptr = _initialize_engine(opts.as_ptr());
+            assert!(!engine_ptr.is_null());
+
+            let engine_addr = engine_ptr as usize;
+
+            let handles: Vec<_> = (0..THREADS)
+                .map(|t| {
+                    std::thread::spawn(move || {
+                        let ptr = engine_addr as *mut c_void;
+                        let variant_req =
+                            CString::new(r#"{"flag_key":"flag1","entity_id":"entity","context":{}}"#)
+                                .unwrap();
+                        let boolean_req = CString::new(
+                            r#"{"flag_key":"flag_boolean","entity_id":"entity","context":{}}"#,
+                        )
+                        .unwrap();
+                        let batch_req = CString::new(
+                            r#"[{"flag_key":"flag1","entity_id":"entity","context":{}},{"flag_key":"flag_boolean","entity_id":"entity","context":{}}]"#,
+                        )
+                        .unwrap();
+
+                        for i in 0..ITERATIONS {
+                            let result_ptr = match (t + i) % 5 {
+                                0 => _evaluate_variant(ptr, variant_req.as_ptr()),
+                                1 => _evaluate_boolean(ptr, boolean_req.as_ptr()),
+                                2 => _evaluate_batch(ptr, batch_req.as_ptr()),
+                                3 => _list_flags(ptr),
+                                _ => _get_snapshot(ptr),
+                            };
+                            assert!(!result_ptr.is_null());
+                            _destroy_string(result_ptr as *mut c_char);
+                        }
+                    })
+                })
+                .collect();
+
+            for handle in handles {
+                handle.join().expect("evaluation thread panicked");
+            }
+
             _destroy_engine(engine_ptr);
         }
     }

--- a/flipt-engine-wasm/src/lib.rs
+++ b/flipt-engine-wasm/src/lib.rs
@@ -158,7 +158,19 @@ impl Engine {
 ///
 /// This function should not be called unless an Engine is initiated. It provides a helper
 /// utility to retrieve an Engine instance for evaluation use.
-unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut Engine, WASMError> {
+unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a Engine, WASMError> {
+    if engine_ptr.is_null() {
+        Err(WASMError::NullPointer)
+    } else {
+        Ok(&*(engine_ptr as *const Engine))
+    }
+}
+
+/// # Safety
+///
+/// This function should not be called unless an Engine is initiated. It provides a helper
+/// utility to retrieve an Engine instance for evaluation use.
+unsafe fn get_engine_mut<'a>(engine_ptr: *mut c_void) -> Result<&'a mut Engine, WASMError> {
     if engine_ptr.is_null() {
         Err(WASMError::NullPointer)
     } else {
@@ -396,7 +408,7 @@ pub unsafe extern "C" fn snapshot(
     snapshot_len: usize,
 ) -> u64 {
     let result = std::panic::catch_unwind(|| {
-        let e = match get_engine(engine_ptr) {
+        let e = match get_engine_mut(engine_ptr) {
             Ok(e) => e,
             Err(e) => return result_to_ptr::<(), _>(Err(e)),
         };
@@ -438,7 +450,7 @@ pub unsafe extern "C" fn seed_snapshot(
     snapshot_len: usize,
 ) -> u64 {
     let result = std::panic::catch_unwind(|| {
-        let e = match get_engine(engine_ptr) {
+        let e = match get_engine_mut(engine_ptr) {
             Ok(e) => e,
             Err(e) => return result_to_ptr::<(), _>(Err(e)),
         };
@@ -614,6 +626,84 @@ mod tests {
     fn encoded_snapshot(namespace: &str) -> String {
         let snapshot = snapshot::Snapshot::empty(namespace);
         BASE64_STANDARD.encode(serde_json::to_string(&snapshot).expect("serialize snapshot"))
+    }
+
+    #[test]
+    fn test_all_evaluation_methods() {
+        let snapshot = r#"{"namespace":{"key":"default"},"flags":[{"key":"flag1","name":"flag1","enabled":true,"type":"VARIANT_FLAG_TYPE"},{"key":"flag_boolean","name":"flag_boolean","enabled":true,"type":"BOOLEAN_FLAG_TYPE"}]}"#;
+        let engine = Engine::new("default", snapshot).expect("engine");
+
+        let result = engine
+            .evaluate_variant(&EvaluationRequest {
+                flag_key: "flag1".into(),
+                entity_id: "entity".into(),
+                context: HashMap::new(),
+            })
+            .expect("variant evaluation");
+        assert_eq!(result.flag_key, "flag1");
+
+        let result = engine
+            .evaluate_boolean(&EvaluationRequest {
+                flag_key: "flag_boolean".into(),
+                entity_id: "entity".into(),
+                context: HashMap::new(),
+            })
+            .expect("boolean evaluation");
+        assert!(result.enabled);
+
+        let results = engine
+            .evaluate_batch(vec![
+                EvaluationRequest {
+                    flag_key: "flag1".into(),
+                    entity_id: "entity".into(),
+                    context: HashMap::new(),
+                },
+                EvaluationRequest {
+                    flag_key: "flag_boolean".into(),
+                    entity_id: "entity".into(),
+                    context: HashMap::new(),
+                },
+            ])
+            .expect("batch evaluation");
+        assert_eq!(results.responses.len(), 2);
+
+        let flags = engine
+            .list_flags()
+            .expect("list flags")
+            .expect("list flags returned none");
+        assert_eq!(flags.len(), 2);
+
+        let snapshot = engine.get_snapshot().expect("get snapshot");
+        assert!(!snapshot.is_empty());
+    }
+
+    #[test]
+    fn test_snapshot_updates_flags() {
+        let flags_one = r#"{"namespace":{"key":"default"},"flags":[{"key":"flag1","name":"flag1","enabled":true,"type":"VARIANT_FLAG_TYPE"}]}"#;
+        let flags_two = r#"{"namespace":{"key":"default"},"flags":[{"key":"flag1","name":"flag1","enabled":true,"type":"VARIANT_FLAG_TYPE"},{"key":"flag2","name":"flag2","enabled":true,"type":"BOOLEAN_FLAG_TYPE"}]}"#;
+
+        let mut engine = Engine::new("default", flags_one).expect("engine");
+
+        let flags = engine
+            .list_flags()
+            .expect("list flags")
+            .expect("list flags on startup");
+        assert_eq!(flags.len(), 1);
+
+        engine.snapshot(flags_two).expect("snapshot");
+        let flags = engine
+            .list_flags()
+            .expect("list flags")
+            .expect("list flags after snapshot");
+        assert_eq!(flags.len(), 2);
+
+        let empty = r#"{"namespace":{"key":"default"},"flags":[]}"#;
+        engine.snapshot(empty).expect("snapshot");
+        let flags = engine
+            .list_flags()
+            .expect("list flags")
+            .expect("list flags after empty snapshot");
+        assert!(flags.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`get_engine`, the FFI entrypoint helper, returned a `&mut Engine` (an exclusive mutable reference) on every call. A single engine pointer is commonly shared across threads by FFI consumers, so evaluating the same engine concurrently created multiple aliasing `&mut Engine` to the same object — undefined behavior in Rust, which can corrupt the heap under real concurrent load.

Evaluation only needs `&self`, so this changes `get_engine` to return a shared `&Engine`.

## Problem

```rust
unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut Engine, FFIError> {
    ...
    Ok(&mut *(engine_ptr as *mut Engine))
}
```

The snapshot is correctly protected by an `Arc<RwLock<Evaluator>>`, so there is no data race on the flag state. The bug is one level up: every evaluation method (`variant`, `boolean`, `batch`, `list_flags`, `get_snapshot`) takes `&self`, yet the entrypoint materializes a `&mut Engine`. When a shared pointer is evaluated from multiple threads at once, two or more live `&mut` to the same `Engine` exist concurrently. That violates Rust's aliasing rules and is UB regardless of the lock — `rustc` applies `noalias` to `&mut`, and that assumption breaks under concurrent access. (`destroy_engine` is unaffected: it uses `Box::from_raw`, not `get_engine`.)

## Solution

Return a shared reference, since evaluation only needs `&self`.

```rust
unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a Engine, FFIError> {
    ...
    Ok(&*(engine_ptr as *const Engine))
}
```

Every method reachable through `get_engine` takes `&self`, so no caller needs `&mut` and the change compiles with no other modifications. The mutable state (the snapshot) stays guarded by the internal `RwLock`, so background updates keep working, and any number of threads can now evaluate the same pointer concurrently without violating aliasing rules.

## Background

I found this in a production-scale load test. A Python service shared a single client (the `ctypes` wrapper over `libfliptengine.so`) and evaluated it concurrently from many worker threads. The process aborted with glibc's `double free or corruption (!prev)` (`SIGABRT`). A core dump showed 8 threads inside the engine's evaluation path at the moment of the crash, while the thread that tripped the abort was a different one doing unrelated `malloc`/`free` — the classic signature of heap corruption surfacing on whichever thread next touches the heap.