### PR TITLE
chore: release FFI engine v0.21.1

### DIFF
--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-engine-ffi"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"


### PR DESCRIPTION
Bumps flipt-engine-ffi to v0.21.1 so the PR #1817 aliasing UB fix can be released and consumed by FFI SDK package releases.\n\nValidation:\n- cargo check -p flipt-engine-ffi