### PR TITLE
chore: release flipt-engine-ffi v0.21.2

### DIFF
--- a/flipt-engine-ffi/Cargo.toml
+++ b/flipt-engine-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-engine-ffi"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `flipt-engine-ffi` from `0.21.1` to `0.21.2`
- Prepare a patch FFI engine release that includes the packaging/toolchain fixes from #1836

## Why

#1836 pinned Rust engine builds to `1.94.0` and removed nightly-only flags from FFI packaging. Creating a new `flipt-engine-ffi-v0.21.2` tag after this PR merges will trigger the FFI packaging workflows and publish fresh platform binaries with those fixes.

## Verification

- `cargo +1.94.0 check -p flipt-engine-ffi`

## After merge

From an up-to-date `main` branch:

```bash
git pull --ff-only origin main
git tag flipt-engine-ffi-v0.21.2
git push origin flipt-engine-ffi-v0.21.2
```

The tag should trigger the FFI engine packaging workflows for supported platforms.
