### PR TITLE
chore: release flipt-client-python v1.4.3

### DIFF
--- a/flipt-client-python/pyproject.toml
+++ b/flipt-client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "flipt-client"
-version = "1.4.2"
+version = "1.4.3"
 description = "Flipt Client Evaluation SDK"
 authors = [ "Flipt Devs <dev@flipt.io>",]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump `flipt-client-python` from `1.4.2` to `1.4.3`
- Prepare a Python SDK patch release so packaging picks up the newly published `flipt-engine-ffi-v0.21.2` assets

## Why

The bug report behind #1834 required the FFI engine packaging/toolchain fix shipped in #1836 and published as `flipt-engine-ffi-v0.21.2`. Releasing the Python SDK now will publish a new Python package with the fixed FFI binaries.

## Verification

- `mise exec python@3.11 poetry@1.7 black@latest -- bash -lc 'cd /Users/markphelps/workspace/flipt-client-sdks/flipt-client-python && poetry install && poetry run black --check .'`
- `mise exec python@3.11 poetry@1.7 -- bash -lc 'cd /Users/markphelps/workspace/flipt-client-sdks/flipt-client-python && poetry build'`

## After merge

From an up-to-date `main` branch:

```bash
git pull --ff-only origin main
git tag flipt-client-python-v1.4.3
git push origin flipt-client-python-v1.4.3
```

The tag should trigger the Package Python SDK workflow, which uses the latest FFI engine release by default.
