### PR TITLE
chore: release FFI SDKs with fixed engine

### DIFF
--- a/flipt-client-csharp/src/FliptClient/FliptClient.csproj
+++ b/flipt-client-csharp/src/FliptClient/FliptClient.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Flipt.Client</PackageId>
-    <Version>1.3.4</Version>
+    <Version>1.3.5</Version>
     <Authors>Flipt Devs (dev@flipt.io)</Authors>
     <Company>Flipt.io</Company>
     <Description>Flipt Client SDK</Description>

--- a/flipt-client-dart/ios/flipt_client.podspec
+++ b/flipt-client-dart/ios/flipt_client.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'flipt_client'
-  s.version          = '1.2.1' # must match pubspec.yaml
+  s.version          = '1.2.2' # must match pubspec.yaml
   s.summary          = 'Dart FFI bindings for Flipt engine'
   s.description      = 'Precompiled Flipt engine as a static .xcframework for use via Dart FFI.'
   s.homepage         = 'https://github.com/flipt-io/flipt-client-sdks'

--- a/flipt-client-dart/pubspec.yaml
+++ b/flipt-client-dart/pubspec.yaml
@@ -32,4 +32,4 @@ flutter:
         pluginClass: FliptClient
 homepage: https://flipt.io
 name: flipt_client
-version: 1.2.1
+version: 1.2.2

--- a/flipt-client-java/build.gradle
+++ b/flipt-client-java/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'io.flipt'
-version = '1.3.2'
+version = '1.3.3'
 description = 'Flipt Client SDK'
 
 java {

--- a/flipt-client-kotlin-android/build.gradle
+++ b/flipt-client-kotlin-android/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'io.flipt'
-version = '1.3.2'
+version = '1.3.3'
 description = 'Flipt Client SDK'
 
 android {
@@ -24,8 +24,8 @@ android {
         ndk {
             abiFilters "x86_64", "arm64-v8a"
         }
-        versionCode 13
-        versionName "1.3.2"
+        versionCode 14
+        versionName "1.3.3"
     }
 
     buildTypes {

--- a/flipt-client-ruby/lib/flipt_client/version.rb
+++ b/flipt-client-ruby/lib/flipt_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flipt
-  VERSION = '1.3.2'
+  VERSION = '1.3.3'
 end


### PR DESCRIPTION
## Summary

Prepare patch releases for the remaining FFI-based SDKs so their package workflows pick up the fixed `flipt-engine-ffi-v0.21.2` binaries:

- `flipt-client-ruby`: `1.3.2` → `1.3.3`
- `flipt-client-java`: `1.3.2` → `1.3.3`
- `flipt-client-csharp`: `1.3.4` → `1.3.5`
- `flipt-client-dart`: `1.2.1` → `1.2.2`
- `flipt-client-kotlin-android`: `1.3.2` → `1.3.3` (`versionCode` `13` → `14`)

Swift is tag-based, so there is no source version file to update in this PR. It should be tagged as `flipt-client-swift-v1.5.3` alongside these releases after this PR merges.

## Why

Per the latest comments on #1834, the native Linux/aarch64 FFI engine issue also affects other FFI SDKs (confirmed report for Java `1.3.2`). Python `1.4.3` already shipped with the fixed engine assets. This PR prepares the remaining FFI SDK patch releases so new packages bundle `flipt-engine-ffi-v0.21.2`.

## Verification

- `git diff --check`
- Release script version extraction:
  - `flipt-client-ruby: 1.3.3`
  - `flipt-client-java: 1.3.3`
  - `flipt-client-csharp: 1.3.5`
  - `flipt-client-dart: 1.2.2`
  - `flipt-client-kotlin-android: 1.3.3`
  - `flipt-client-swift: 1.5.2` (tag-based current release)

## After merge

From an up-to-date `main` branch, push these tags:

```bash
git pull --ff-only origin main
git tag flipt-client-ruby-v1.3.3
git tag flipt-client-java-v1.3.3
git tag flipt-client-csharp-v1.3.5
git tag flipt-client-dart-v1.2.2
git tag flipt-client-kotlin-android-v1.3.3
git tag flipt-client-swift-v1.5.3
git push origin \
  flipt-client-ruby-v1.3.3 \
  flipt-client-java-v1.3.3 \
  flipt-client-csharp-v1.3.5 \
  flipt-client-dart-v1.2.2 \
  flipt-client-kotlin-android-v1.3.3 \
  flipt-client-swift-v1.5.3
```
