### PR TITLE
fix(android): package armeabi-v7a library

### DIFF
--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -91,20 +91,32 @@ jobs:
           path: /tmp
           run-id: ${{ github.event.workflow_run.id }}
 
+      - name: Download Artifact (Android armv7)
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          name: flipt-engine-ffi-Android-armv7.tar.gz
+          path: /tmp
+          run-id: ${{ github.event.workflow_run.id }}
+
       - name: Extract Artifacts
         run: |
           mkdir -p /tmp/flipt-engine-ffi-Android-x86_64
           mkdir -p /tmp/flipt-engine-ffi-Android-aarch64
+          mkdir -p /tmp/flipt-engine-ffi-Android-armv7
           tar -xzvf /tmp/flipt-engine-ffi-Android-x86_64.tar.gz -C /tmp/flipt-engine-ffi-Android-x86_64
           tar -xzvf /tmp/flipt-engine-ffi-Android-aarch64.tar.gz -C /tmp/flipt-engine-ffi-Android-aarch64
+          tar -xzvf /tmp/flipt-engine-ffi-Android-armv7.tar.gz -C /tmp/flipt-engine-ffi-Android-armv7
 
       - name: Move Artifacts
         run: |
           mkdir -p flipt-client-kotlin-android/src/main/cpp/libs/x86_64
           mkdir -p flipt-client-kotlin-android/src/main/cpp/libs/arm64-v8a
+          mkdir -p flipt-client-kotlin-android/src/main/cpp/libs/armeabi-v7a
           mkdir -p flipt-client-kotlin-android/src/main/cpp/include
           mv /tmp/flipt-engine-ffi-Android-x86_64/target/x86_64-linux-android/release/libfliptengine.a flipt-client-kotlin-android/src/main/cpp/libs/x86_64/
           mv /tmp/flipt-engine-ffi-Android-aarch64/target/aarch64-linux-android/release/libfliptengine.a flipt-client-kotlin-android/src/main/cpp/libs/arm64-v8a/
+          mv /tmp/flipt-engine-ffi-Android-armv7/target/armv7-linux-androideabi/release/libfliptengine.a flipt-client-kotlin-android/src/main/cpp/libs/armeabi-v7a/
           cp flipt-engine-ffi/include/flipt_engine.h flipt-client-kotlin-android/src/main/cpp/include/
 
       - name: Run Flipt
@@ -200,20 +212,29 @@ jobs:
           curl -L -o /tmp/flipt-engine-ffi-Android-aarch64.tar.gz \
             https://github.com/flipt-io/flipt-client-sdks/releases/download/flipt-engine-ffi-${{ github.event.inputs.release_tag }}/flipt-engine-ffi-Android-aarch64.tar.gz
 
+      - name: Download Artifact (Android armv7)
+        run: |
+          curl -L -o /tmp/flipt-engine-ffi-Android-armv7.tar.gz \
+            https://github.com/flipt-io/flipt-client-sdks/releases/download/flipt-engine-ffi-${{ github.event.inputs.release_tag }}/flipt-engine-ffi-Android-armv7.tar.gz
+
       - name: Extract Artifacts
         run: |
           mkdir -p /tmp/flipt-engine-ffi-Android-x86_64
           mkdir -p /tmp/flipt-engine-ffi-Android-aarch64
+          mkdir -p /tmp/flipt-engine-ffi-Android-armv7
           tar -xzvf /tmp/flipt-engine-ffi-Android-x86_64.tar.gz -C /tmp/flipt-engine-ffi-Android-x86_64
           tar -xzvf /tmp/flipt-engine-ffi-Android-aarch64.tar.gz -C /tmp/flipt-engine-ffi-Android-aarch64
+          tar -xzvf /tmp/flipt-engine-ffi-Android-armv7.tar.gz -C /tmp/flipt-engine-ffi-Android-armv7
 
       - name: Move Artifacts
         run: |
           mkdir -p flipt-client-kotlin-android/src/main/cpp/libs/x86_64
           mkdir -p flipt-client-kotlin-android/src/main/cpp/libs/arm64-v8a
+          mkdir -p flipt-client-kotlin-android/src/main/cpp/libs/armeabi-v7a
           mkdir -p flipt-client-kotlin-android/src/main/cpp/include
           mv /tmp/flipt-engine-ffi-Android-x86_64/target/x86_64-linux-android/release/libfliptengine.a flipt-client-kotlin-android/src/main/cpp/libs/x86_64/
           mv /tmp/flipt-engine-ffi-Android-aarch64/target/aarch64-linux-android/release/libfliptengine.a flipt-client-kotlin-android/src/main/cpp/libs/arm64-v8a/
+          mv /tmp/flipt-engine-ffi-Android-armv7/target/armv7-linux-androideabi/release/libfliptengine.a flipt-client-kotlin-android/src/main/cpp/libs/armeabi-v7a/
           cp flipt-engine-ffi/include/flipt_engine.h flipt-client-kotlin-android/src/main/cpp/include/
 
       - name: Run Flipt

--- a/flipt-client-kotlin-android/README.md
+++ b/flipt-client-kotlin-android/README.md
@@ -69,7 +69,8 @@ Retriable errors include:
 This SDK currently supports the following OSes/architectures:
 
 - Android x86_64
-- Android arm64
+- Android arm64 (`arm64-v8a`)
+- Android 32-bit ARM (`armeabi-v7a`)
 
 ## Migration Notes
 

--- a/flipt-client-kotlin-android/build.gradle
+++ b/flipt-client-kotlin-android/build.gradle
@@ -22,7 +22,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
         ndk {
-            abiFilters "x86_64", "arm64-v8a"
+            abiFilters "x86_64", "arm64-v8a", "armeabi-v7a"
         }
         versionCode 14
         versionName "1.3.3"

--- a/flipt-client-kotlin-android/src/main/cpp/CMakeLists.txt
+++ b/flipt-client-kotlin-android/src/main/cpp/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library( libfliptengine STATIC IMPORTED )
 
 if (${ANDROID_ABI} STREQUAL "arm64-v8a")
     set_property(TARGET libfliptengine PROPERTY IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/libs/arm64-v8a/libfliptengine.a")
+elseif (${ANDROID_ABI} STREQUAL "armeabi-v7a")
+    set_property(TARGET libfliptengine PROPERTY IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/libs/armeabi-v7a/libfliptengine.a")
 elseif (${ANDROID_ABI} STREQUAL "x86_64")
     set_property(TARGET libfliptengine PROPERTY IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/libs/x86_64/libfliptengine.a")
 endif()

--- a/package/ffi/sdks/android.go
+++ b/package/ffi/sdks/android.go
@@ -17,6 +17,7 @@ type AndroidSDK struct {
 func (s *AndroidSDK) SupportedPlatforms() []platform.Platform {
 	return []platform.Platform{
 		platform.AndroidArm64,
+		platform.AndroidArmv7,
 		platform.AndroidX86_64,
 	}
 }
@@ -25,10 +26,12 @@ func (s *AndroidSDK) Build(ctx context.Context, client *dagger.Client, container
 	// the directory structure of the tmp directory is as follows:
 	// tmp/android_x86_64/
 	// tmp/android_aarch64/
+	// tmp/android_armv7/
 
 	// we need to convert it to the following structure:
 	// staging/x86_64/
 	// staging/arm64-v8a/
+	// staging/armeabi-v7a/
 
 	// this is because the Android SDK expects the library to be in a specific directory structure based on host OS and architecture
 
@@ -40,6 +43,7 @@ func (s *AndroidSDK) Build(ctx context.Context, client *dagger.Client, container
 	renames := []rename{
 		{old: "android_x86_64", new: "x86_64"},
 		{old: "android_aarch64", new: "arm64-v8a"},
+		{old: "android_armv7", new: "armeabi-v7a"},
 	}
 
 	if err := os.RemoveAll("staging"); err != nil {

--- a/package/ffi/sdks/android_test.go
+++ b/package/ffi/sdks/android_test.go
@@ -1,0 +1,15 @@
+package sdks
+
+import "testing"
+
+func TestAndroidSDKSupportsAndroidArmv7(t *testing.T) {
+	sdk := &AndroidSDK{}
+
+	for _, platform := range sdk.SupportedPlatforms() {
+		if platform.ID == "Android-armv7" && platform.Target == "armv7-linux-androideabi" {
+			return
+		}
+	}
+
+	t.Fatalf("Android SDK supported platforms must include Android-armv7/armv7-linux-androideabi for armeabi-v7a support; got %#v", sdk.SupportedPlatforms())
+}


### PR DESCRIPTION
## Summary

Fixes #1852 by including the Android 32-bit ARM (`armeabi-v7a`) native wrapper in the Kotlin Android SDK AAR.

- Include `Android-armv7` when assembling the Android SDK package and stage it under `armeabi-v7a`.
- Configure Gradle and CMake to build and link the armv7 wrapper.
- Download and stage the armv7 engine artifact in both Android SDK CI paths.
- Document the supported ABI and add a regression test for armv7 package-platform selection.

The FFI engine release pipeline already builds and publishes the `Android-armv7` artifact; this change carries it through the Kotlin Android SDK package.

## Verification

- `go test ./package/ffi/sdks`
- `cd flipt-client-kotlin-android && mise run lint`
- Parsed `.github/workflows/test-android-sdk.yml` successfully with Ruby YAML