### PR TITLE
chore(wasm): bump wasm engine to v0.4.0 and wasm-js to v0.4.1

### DIFF
--- a/flipt-engine-wasm-js/Cargo.toml
+++ b/flipt-engine-wasm-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-engine-wasm-js"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"

--- a/flipt-engine-wasm/Cargo.toml
+++ b/flipt-engine-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipt-engine-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Flipt Devs <dev@flipt.io>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

The WASM engine version numbers and their bookkeeping tags went stale. `flipt-engine-wasm-v0.3.0` and `flipt-engine-wasm-js-v0.4.0` both point at commits that predate real engine changes, and neither `Cargo.toml` was bumped afterwards.

This PR brings the versions back in line so the tags can be re-cut.

## flipt-engine-wasm: 0.3.0 -> 0.4.0 (minor)

Unreleased since `flipt-engine-wasm-v0.3.0`:

- `78730ff` feat: add Go WASM snapshot support (#1800) — new snapshot API, so this is a minor bump
- `a532a70` fix: return shared &Engine from get_engine to fix aliasing UB (#1817)
- `e3b488f` chore(deps): update mockall requirement in /flipt-evaluation (#1819)
- `73ed61a` chore(deps): update base64 requirement in /flipt-engine-wasm (#1877)

## flipt-engine-wasm-js: 0.4.0 -> 0.4.1 (patch)

Unreleased since `flipt-engine-wasm-js-v0.4.0`:

- `78730ff` reject a seeded snapshot whose namespace does not match the engine
- `e3b488f` chore(deps): update mockall requirement in /flipt-evaluation (#1819)
- `f8e6921` chore(deps): update base64 requirement in /flipt-engine-wasm-js (#1881)

No new API in the JS engine, so a patch is enough.

## Why this matters

`a532a70` is an aliasing UB fix that has never shipped in any released Go SDK. Releasing `flipt-client-go` after this lands is what gets it to users.

## Next steps after merge

1. Push `flipt-engine-wasm-v0.4.0` and `flipt-engine-wasm-js-v0.4.1`. These are bookkeeping tags; they do not trigger binary builds.
2. Release `flipt-client-go`, then `flipt-client-js`, then `flipt-client-react`. Each bundles the WASM engine built from source at release time.

## Test plan

- `cargo check` passes.