### PR TITLE
fix(ci): move FFI build image off EOL bullseye, relax codecov gate

### DIFF
--- a/.github/workflows/test-engines.yml
+++ b/.github/workflows/test-engines.yml
@@ -72,9 +72,12 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
+      # Dependabot and fork pull requests cannot read CODECOV_TOKEN, and Codecov
+      # rejects tokenless uploads on a protected branch. Report the upload but do
+      # not fail the job when the token is unavailable.
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}

--- a/test/main.go
+++ b/test/main.go
@@ -356,7 +356,10 @@ func createBaseContainer(client *dagger.Client, config containerConfig) *dagger.
 // their tests against.
 func getFFIBuildContainer(_ context.Context, client *dagger.Client, hostDirectory *dagger.Directory, arch arch) *dagger.Container {
 	return client.Container().
-		From("rust:1.83.0-bullseye"). // requires older version of glibc for best compatibility
+		// bookworm, not bullseye: bullseye LTS ended and its security Release file
+		// is expired, which makes apt-get update fail. The engine is linked statically
+		// against musl, so the base image glibc does not affect the artifact.
+		From("rust:1.83.0-bookworm").
 		WithExec(args("apt-get update")).
 		WithExec(args("apt-get install -y build-essential musl-dev musl-tools")).
 		WithWorkdir("/src").

--- a/test/main.go
+++ b/test/main.go
@@ -356,11 +356,12 @@ func createBaseContainer(client *dagger.Client, config containerConfig) *dagger.
 // their tests against.
 func getFFIBuildContainer(_ context.Context, client *dagger.Client, hostDirectory *dagger.Directory, arch arch) *dagger.Container {
 	return client.Container().
-		// bookworm, not bullseye: bullseye LTS ended and its security Release file
-		// is expired, which makes apt-get update fail. The engine is linked statically
-		// against musl, so the base image glibc does not affect the artifact.
-		From("rust:1.83.0-bookworm").
-		WithExec(args("apt-get update")).
+		// Stay on bullseye. musl-gcc links against the host libgcc, so a newer base
+		// pulls in _dl_find_object and the engine then fails to load on alpine and on
+		// glibc older than 2.35. Bullseye LTS has ended and its security Release file
+		// is expired, so apt needs Check-Valid-Until turned off to read it.
+		From("rust:1.83.0-bullseye").
+		WithExec(args("apt-get -o Acquire::Check-Valid-Until=false update")).
 		WithExec(args("apt-get install -y build-essential musl-dev musl-tools")).
 		WithWorkdir("/src").
 		WithDirectory("/src/flipt-engine-ffi", hostDirectory.Directory("flipt-engine-ffi")).


### PR DESCRIPTION
## Why

Two unrelated infrastructure problems make almost every open pull request red.

### 1. All five FFI integration test jobs fail

`getFFIBuildContainer` builds the engine in `rust:1.83.0-bullseye` and runs `apt-get update` to install `musl-tools`. Debian bullseye LTS ended on 2026-08-31, and the `bullseye-security` `Release` file expired on 2026-09-07:

```
Suite: oldoldstable-security
Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC
```

apt refuses an expired `Release` file and exits 100. Every FFI SDK job then fails with:

```
process "apt-get update" did not complete successfully: exit code: 100
```

This is why #1951, a JavaScript-only change, fails python, ruby, java, dart and csharp while the wasm and js groups pass. The same jobs were green on 2026-09-07.

The fix turns off the `Valid-Until` check rather than moving the image forward. Moving to bookworm was tried first and produced a broken artifact: `musl-gcc` links against the host `libgcc`, and the bookworm one references `_dl_find_object`, a glibc 2.35 symbol. The engine then failed to load on alpine and bullseye:

```
OSError: Error relocating .../libfliptengine.so: _dl_find_object: symbol not found
```

Release builds run on `ubuntu-22.04`, so bullseye is the toolchain vintage that matches what ships. The comment on that line was load bearing.

### 2. The Coverage job fails on every Dependabot pull request

```
Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

Dependabot and fork pull requests cannot read `CODECOV_TOKEN`, and Codecov rejects tokenless uploads against a protected branch. With `fail_ci_if_error: true` the job fails and the pull request goes red for a reason unrelated to its content.

## What changed

- `test/main.go`: `apt-get update` in the FFI build container now passes `-o Acquire::Check-Valid-Until=false`.
- `.github/workflows/test-engines.yml`: `fail_ci_if_error` is now true only when `CODECOV_TOKEN` is available.

## Follow-ups not covered here

- This buys time rather than fixing the root problem. Bullseye is end of life and will eventually move to `archive.debian.org`, which breaks the apt URLs outright. The durable fix is to stop depending on the base image toolchain, for example by vendoring a musl cross toolchain or building the wrapper without the host `libgcc`.
- The same glibc trap applies to the release workflow. `package-ffi-engine-linux.yml` pins `ubuntu-22.04`; bumping it to 24.04 would ship an engine that cannot load on alpine or older glibc.
- Adding `CODECOV_TOKEN` to the repository Dependabot secrets would let coverage upload on those pull requests instead of being skipped. That is a repository settings change.
- Several Dependabot pull requests fail for their own reasons, not this one. Examples: junit-bom 6 (#1900), TypeScript 7 (#1863, #1860), React 19 types (#1868, #1808), reqwest-middleware 0.5 (#1752, #1754).

https://claude.ai/code/session_01SQAJuCpTNLr3v9jJXPzoaa